### PR TITLE
Improve CLI Output, with a Formatter class

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -194,7 +194,7 @@ module Hanami
                   out.puts ""
                   out.puts Formatter.dim("Next steps:")
                   out.puts Formatter.dim("  cd #{app}")
-                  out.puts Formatter.dim("  bundle exec hanami server")
+                  out.puts Formatter.dim("  bundle exec hanami dev")
                 end
               end
             end

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -2,6 +2,7 @@
 
 require "dry/inflector"
 require_relative "../../errors"
+require_relative "../../formatter"
 
 module Hanami
   module CLI
@@ -157,31 +158,43 @@ module Hanami
                 skip_view: skip_view,
                 database: normalized_database
               )
+              out.puts Formatter.header("Setting up #{app}...")
+
               generator.call(app, context: context) do
                 if skip_install
-                  out.puts "Skipping installation, please enter `#{app}' directory and run `bundle exec hanami install'"
+                  out.puts ""
+                  out.puts Formatter.info("Skipping installation")
+                  out.puts Formatter.dim("  To complete setup, run: cd #{app} && bundle exec hanami install")
                 else
-                  out.puts "Running bundle install..."
+                  out.puts ""
+                  out.puts Formatter.info("Installing dependencies...")
                   bundler.install!
 
                   unless skip_assets
-                    out.puts "Running npm install..."
+                    out.puts Formatter.info("Installing npm packages...")
                     system_call.call("npm", ["install"]).tap do |result|
                       unless result.successful?
-                        puts "NPM ERROR:"
-                        puts(result.err.lines.map { |line| line.prepend("    ") })
+                        out.puts Formatter.error("NPM installation failed:")
+                        out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}") })
                       end
                     end
                   end
 
-                  out.puts "Running hanami install..."
+                  out.puts Formatter.info("Running hanami install...")
                   run_install_command!(head: head)
 
-                  out.puts "Running bundle binstubs hanami-cli rake..."
+                  out.puts Formatter.info("Running bundle binstubs hanami-cli rake...")
                   install_binstubs!
 
-                  out.puts "Initializing git repository..."
+                  out.puts Formatter.info("Initializing git repository...")
                   init_git_repository
+
+                  out.puts ""
+                  out.puts Formatter.success("Successfully created #{app}!")
+                  out.puts ""
+                  out.puts Formatter.dim("Next steps:")
+                  out.puts Formatter.dim("  cd #{app}")
+                  out.puts Formatter.dim("  bundle exec hanami server")
                 end
               end
             end
@@ -227,8 +240,8 @@ module Hanami
           def init_git_repository
             system_call.call("git", ["init"]).tap do |result|
               unless result.successful?
-                out.puts "WARNING: Failed to initialize git repository"
-                out.puts(result.err.lines.map { |line| line.prepend("    ") })
+                out.puts Formatter.warning("Failed to initialize git repository")
+                out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}") })
               end
             end
           end

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -158,43 +158,43 @@ module Hanami
                 skip_view: skip_view,
                 database: normalized_database
               )
-              out.puts Formatter.header("Setting up #{app}...")
+              out.puts Formatter.header("Setting up #{app}...", out: out)
 
               generator.call(app, context: context) do
                 if skip_install
                   out.puts ""
-                  out.puts Formatter.info("Skipping installation")
-                  out.puts Formatter.dim("  To complete setup, run: cd #{app} && bundle exec hanami install")
+                  out.puts Formatter.info("Skipping installation", out: out)
+                  out.puts Formatter.dim("  To complete setup, run: cd #{app} && bundle exec hanami install", out: out)
                 else
                   out.puts ""
-                  out.puts Formatter.info("Installing dependencies...")
+                  out.puts Formatter.info("Installing dependencies...", out: out)
                   bundler.install!
 
                   unless skip_assets
-                    out.puts Formatter.info("Installing npm packages...")
+                    out.puts Formatter.info("Installing npm packages...", out: out)
                     system_call.call("npm", ["install"]).tap do |result|
                       unless result.successful?
-                        out.puts Formatter.error("NPM installation failed:")
-                        out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}") })
+                        out.puts Formatter.error("NPM installation failed:", out: out)
+                        out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}", out: out) })
                       end
                     end
                   end
 
-                  out.puts Formatter.info("Running hanami install...")
+                  out.puts Formatter.info("Running hanami install...", out: out)
                   run_install_command!(head: head)
 
-                  out.puts Formatter.info("Running bundle binstubs hanami-cli rake...")
+                  out.puts Formatter.info("Running bundle binstubs hanami-cli rake...", out: out)
                   install_binstubs!
 
-                  out.puts Formatter.info("Initializing git repository...")
+                  out.puts Formatter.info("Initializing git repository...", out: out)
                   init_git_repository
 
                   out.puts ""
-                  out.puts Formatter.success("Successfully created #{app}!")
+                  out.puts Formatter.success("Successfully created #{app}!", out: out)
                   out.puts ""
-                  out.puts Formatter.dim("Next steps:")
-                  out.puts Formatter.dim("  cd #{app}")
-                  out.puts Formatter.dim("  bundle exec hanami dev")
+                  out.puts Formatter.dim("Next steps:", out: out)
+                  out.puts Formatter.dim("  cd #{app}", out: out)
+                  out.puts Formatter.dim("  bundle exec hanami dev", out: out)
                 end
               end
             end
@@ -240,8 +240,8 @@ module Hanami
           def init_git_repository
             system_call.call("git", ["init"]).tap do |result|
               unless result.successful?
-                out.puts Formatter.warning("Failed to initialize git repository")
-                out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}") })
+                out.puts Formatter.warning("Failed to initialize git repository", out: out)
+                out.puts(result.err.lines.map { |line| Formatter.dim("    #{line}", out: out) })
               end
             end
           end

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/files"
+require_relative "formatter"
 
 module Hanami
   module CLI
@@ -43,7 +44,7 @@ module Hanami
         return if exist?(path)
 
         super
-        created(dir_path(path))
+        created_directory(dir_path(path))
       end
 
       # @since 2.0.0
@@ -83,15 +84,19 @@ module Hanami
       end
 
       def updated(path)
-        out.puts "Updated #{path}"
+        out.puts Formatter.updated(path)
       end
 
       def created(path)
-        out.puts "Created #{path}"
+        out.puts Formatter.created(path)
+      end
+
+      def created_directory(path)
+        out.puts Formatter.created_directory(path)
       end
 
       def within_folder(path)
-        out.puts "-> Within #{dir_path(path)}"
+        out.puts Formatter.dim("-> Entering `#{path}/` directory...")
       end
 
       def dir_path(path)

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -84,19 +84,19 @@ module Hanami
       end
 
       def updated(path)
-        out.puts Formatter.updated(path)
+        out.puts Formatter.updated(path, out: out)
       end
 
       def created(path)
-        out.puts Formatter.created(path)
+        out.puts Formatter.created(path, out: out)
       end
 
       def created_directory(path)
-        out.puts Formatter.created_directory(path)
+        out.puts Formatter.created_directory(path, out: out)
       end
 
       def within_folder(path)
-        out.puts Formatter.dim("-> Entering `#{path}/` directory...")
+        out.puts Formatter.dim("-> Entering `#{path}/` directory...", out: out)
       end
 
       def dir_path(path)

--- a/lib/hanami/cli/formatter.rb
+++ b/lib/hanami/cli/formatter.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    # Provides formatting utilities for CLI output including colors and icons
+    #
+    # @api private
+    # @since 2.3.0
+    module Formatter
+      # ANSI color codes
+      COLORS = {
+        reset: "\e[0m",
+        bold: "\e[1m",
+        green: "\e[32m",
+        blue: "\e[34m",
+        cyan: "\e[36m",
+        yellow: "\e[33m",
+        red: "\e[31m",
+        gray: "\e[90m"
+      }.freeze
+
+      # Icons for different operations
+      ICONS = {
+        create: "✓",
+        update: "↻",
+        info: "→",
+        warning: "⚠",
+        error: "✗",
+        success: "✓"
+      }.freeze
+
+      module_function
+
+      # Wraps text in color codes
+      #
+      # @param text [String] the text to colorize
+      # @param color [Symbol] the color name from COLORS
+      # @return [String] colorized text
+      #
+      # @api private
+      def colorize(text, color)
+        return text unless $stdout.tty?
+
+        "#{COLORS[color]}#{text}#{COLORS[:reset]}"
+      end
+
+      # Formats a create message
+      #
+      # @param path [String] the path that was created
+      # @return [String] formatted message
+      #
+      # @api private
+      def created(path)
+        icon = colorize(ICONS[:create], :green)
+        label = colorize("create", :green)
+        "  #{icon} #{label}  #{path}"
+      end
+
+      # Formats a create directory message
+      #
+      # @param path [String] the directory path that was created
+      # @return [String] formatted message
+      #
+      # @api private
+      def created_directory(path)
+        icon = colorize(ICONS[:create], :green)
+        label = colorize("create directory", :green)
+        "#{icon} #{label}  #{path}"
+      end
+
+      # Formats an update message
+      #
+      # @param path [String] the path that was updated
+      # @return [String] formatted message
+      #
+      # @api private
+      def updated(path)
+        icon = colorize(ICONS[:update], :cyan)
+        label = colorize("update", :cyan)
+        "  #{icon} #{label}  #{path}"
+      end
+
+      # Formats an info message
+      #
+      # @param text [String] the message text
+      # @return [String] formatted message
+      #
+      # @api private
+      def info(text)
+        icon = colorize(ICONS[:info], :blue)
+        "#{icon} #{text}"
+      end
+
+      # Formats a success message
+      #
+      # @param text [String] the message text
+      # @return [String] formatted message
+      #
+      # @api private
+      def success(text)
+        icon = colorize(ICONS[:success], :green)
+        label = colorize("✓", :green)
+        "#{label} #{colorize(text, :green)}"
+      end
+
+      # Formats a warning message
+      #
+      # @param text [String] the message text
+      # @return [String] formatted message
+      #
+      # @api private
+      def warning(text)
+        icon = colorize(ICONS[:warning], :yellow)
+        label = colorize("warning", :yellow)
+        "#{icon} #{label} #{text}"
+      end
+
+      # Formats an error message
+      #
+      # @param text [String] the message text
+      # @return [String] formatted message
+      #
+      # @api private
+      def error(text)
+        icon = colorize(ICONS[:error], :red)
+        label = colorize("error", :red)
+        "#{icon} #{label} #{text}"
+      end
+
+      # Formats a section header
+      #
+      # @param text [String] the header text
+      # @return [String] formatted header
+      #
+      # @api private
+      def header(text)
+        "\n#{colorize(text, :bold)}"
+      end
+
+      # Formats a dim/secondary text
+      #
+      # @param text [String] the text to dim
+      # @return [String] formatted text
+      #
+      # @api private
+      def dim(text)
+        text # No special dim color, just return plain text for now
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/formatter.rb
+++ b/lib/hanami/cli/formatter.rb
@@ -37,11 +37,12 @@ module Hanami
       #
       # @param text [String] the text to colorize
       # @param color [Symbol] the color name from COLORS
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] colorized text
       #
       # @api private
-      def colorize(text, color)
-        return text unless $stdout.tty?
+      def colorize(text, color, out: $stdout)
+        return text unless out.tty?
 
         "#{COLORS[color]}#{text}#{COLORS[:reset]}"
       end
@@ -49,103 +50,112 @@ module Hanami
       # Formats a create message
       #
       # @param path [String] the path that was created
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def created(path)
-        icon = colorize(ICONS[:create], :green)
-        label = colorize("create", :green)
+      def created(path, out: $stdout)
+        icon = colorize(ICONS[:create], :green, out: out)
+        label = colorize("create", :green, out: out)
         "  #{icon} #{label}  #{path}"
       end
 
       # Formats a create directory message
       #
       # @param path [String] the directory path that was created
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def created_directory(path)
-        icon = colorize(ICONS[:create], :green)
-        label = colorize("create directory", :green)
+      def created_directory(path, out: $stdout)
+        icon = colorize(ICONS[:create], :green, out: out)
+        label = colorize("create directory", :green, out: out)
         "#{icon} #{label}  #{path}"
       end
 
       # Formats an update message
       #
       # @param path [String] the path that was updated
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def updated(path)
-        icon = colorize(ICONS[:update], :cyan)
-        label = colorize("update", :cyan)
+      def updated(path, out: $stdout)
+        icon = colorize(ICONS[:update], :cyan, out: out)
+        label = colorize("update", :cyan, out: out)
         "  #{icon} #{label}  #{path}"
       end
 
       # Formats an info message
       #
       # @param text [String] the message text
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def info(text)
-        icon = colorize(ICONS[:info], :blue)
+      def info(text, out: $stdout)
+        icon = colorize(ICONS[:info], :blue, out: out)
         "#{icon} #{text}"
       end
 
       # Formats a success message
       #
       # @param text [String] the message text
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def success(text)
-        icon = colorize(ICONS[:success], :green)
-        label = colorize("✓", :green)
-        "#{label} #{colorize(text, :green)}"
+      def success(text, out: $stdout)
+        icon = colorize(ICONS[:success], :green, out: out)
+        label = colorize("✓", :green, out: out)
+        "#{label} #{colorize(text, :green, out: out)}"
       end
 
       # Formats a warning message
       #
       # @param text [String] the message text
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def warning(text)
-        icon = colorize(ICONS[:warning], :yellow)
-        label = colorize("warning", :yellow)
+      def warning(text, out: $stdout)
+        icon = colorize(ICONS[:warning], :yellow, out: out)
+        label = colorize("warning", :yellow, out: out)
         "#{icon} #{label} #{text}"
       end
 
       # Formats an error message
       #
       # @param text [String] the message text
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted message
       #
       # @api private
-      def error(text)
-        icon = colorize(ICONS[:error], :red)
-        label = colorize("error", :red)
+      def error(text, out: $stdout)
+        icon = colorize(ICONS[:error], :red, out: out)
+        label = colorize("error", :red, out: out)
         "#{icon} #{label} #{text}"
       end
 
       # Formats a section header
       #
       # @param text [String] the header text
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted header
       #
       # @api private
-      def header(text)
-        "\n#{colorize(text, :bold)}"
+      def header(text, out: $stdout)
+        "\n#{colorize(text, :bold, out: out)}"
       end
 
       # Formats a dim/secondary text
       #
       # @param text [String] the text to dim
+      # @param out [IO] the output stream to check for TTY (defaults to $stdout)
       # @return [String] formatted text
       #
       # @api private
-      def dim(text)
+      def dim(text, out: $stdout)
         text # No special dim color, just return plain text for now
       end
     end

--- a/lib/hanami/cli/formatter.rb
+++ b/lib/hanami/cli/formatter.rb
@@ -4,6 +4,8 @@ module Hanami
   module CLI
     # Provides formatting utilities for CLI output including colors and icons
     #
+    # There is significant overlap with Hanami-Utils ShellColor module, but hasn't been merged together yet.
+    #
     # @api private
     # @since 2.3.0
     module Formatter

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         within_application_directory do
           generate_action
 
-          expect(output).to include("Updated config/routes.rb")
-          expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
-          expect(output).to include("Created app/views/#{controller}/#{action}.rb")
-          expect(output).to include("Created app/templates/#{controller}/#{action}.html.erb")
+          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
         end
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # route
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         # action
         action_file = <<~EXPECTED
@@ -142,7 +142,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
 
         expect(fs.directory?("app/views/#{controller}")).to eq(false)
         expect(fs.exist?("app/views/#{controller}/#{action}.rb")).to eq(false)
@@ -177,31 +177,31 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: "users.index")
         expect(fs.read("config/routes.rb")).to match(%(get "/users", to: "users.index"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.new")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/new", to: "users.new"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.create")
         expect(fs.read("config/routes.rb")).to match(%(post "/users", to: "users.create"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.edit")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/:id/edit", to: "users.edit"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.update")
         expect(fs.read("config/routes.rb")).to match(%(patch "/users/:id", to: "users.update"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.show")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/:id", to: "users.show"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         subject.call(name: "users.destroy")
         expect(fs.read("config/routes.rb")).to match(%(delete "/users/:id", to: "users.destroy"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
       end
     end
 
@@ -209,7 +209,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: "talent.apply", url_path: "/talent/apply")
         expect(fs.read("config/routes.rb")).to match(%(get "/talent/apply", to: "talent.apply"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
       end
     end
 
@@ -217,7 +217,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: action_name, url_path: "/people")
         expect(fs.read("config/routes.rb")).to match(%(get "/people", to: "users.index"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: action_name, http_method: "put")
         expect(fs.read("config/routes.rb")).to match(%(put "/users", to: "users.index"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
       end
     end
 
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         subject.call(name: action_name, skip_view: true)
 
         expect(fs.read("config/routes.rb")).to match(%(get "/api/users/thing", to: "api.users.thing"))
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         action_file = <<~EXPECTED
           # frozen_string_literal: true
@@ -256,7 +256,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/api/users/thing.rb")).to eq(action_file)
-        expect(output).to include("Created app/actions/api/users/thing.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/api/users/thing.rb")
       end
     end
 
@@ -337,7 +337,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # route
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("Updated config/routes.rb")
+        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
         # action
         action_file = <<~EXPECTED
@@ -356,7 +356,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
 
         # view
         view_file = <<~EXPECTED
@@ -373,7 +373,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/views/#{controller}/#{action}.rb")).to eq(view_file)
-        expect(output).to include("Created app/views/#{controller}/#{action}.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
 
         # template
         expect(fs.directory?("app/templates/#{controller}")).to be(true)
@@ -383,7 +383,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        expect(output).to include("Created app/templates/#{controller}/#{action}.html.erb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
       end
     end
 
@@ -394,7 +394,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           subject.call(name: action_name)
 
           expect(fs.read("config/routes.rb")).to match(%(get "/api/users/thing", to: "api.users.thing"))
-          expect(output).to include("Updated config/routes.rb")
+          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -414,7 +414,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           EXPECTED
 
           expect(fs.read("app/actions/api/users/thing.rb")).to eq(action_file)
-          expect(output).to include("Created app/actions/api/users/thing.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/api/users/thing.rb")
         end
       end
     end
@@ -457,7 +457,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
 
         # view
         view_file = <<~EXPECTED
@@ -474,7 +474,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/views/#{controller}/#{action}.rb")).to eq(view_file)
-        expect(output).to include("Created app/views/#{controller}/#{action}.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
 
         # template
         expect(fs.directory?("app/templates/#{controller}")).to be(true)
@@ -484,7 +484,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        expect(output).to include("Created app/templates/#{controller}/#{action}.html.erb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
       end
     end
 
@@ -569,7 +569,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("Updated config/routes.rb")
+            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
             expected_action = <<~CODE
               # frozen_string_literal: true
@@ -586,7 +586,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             CODE
             expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-            expect(output).to include("Created app/actions/users/create.rb")
+            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
 
             expect(fs.exist?("app/views/users/create.rb")).to be(false)
             expect(fs.exist?("app/templates/users/create.html.erb")).to be(false)
@@ -631,7 +631,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("Updated config/routes.rb")
+              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -648,7 +648,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-              expect(output).to include("Created app/actions/users/create.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
 
               expected_view = <<~CODE
                 # frozen_string_literal: true
@@ -663,14 +663,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/views/users/create.rb")).to eq(expected_view)
-              expect(output).to include("Created app/views/users/create.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/create.rb")
 
               expected_template = <<~EXPECTED
                 <h1>#{inflector.camelize(app)}::Views::Users::Create</h1>
               EXPECTED
 
               expect(fs.read("app/templates/users/create.html.erb")).to eq(expected_template)
-              expect(output).to include("Created app/templates/users/create.html.erb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/create.html.erb")
             end
           end
 
@@ -708,7 +708,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("Updated config/routes.rb")
+              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -726,7 +726,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-              expect(output).to include("Created app/actions/users/create.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
 
               expect(fs.exist?("app/views/users/create.rb")).to be(false)
               expect(fs.exist?("app/templates/users/create.html.erb")).to be(false)
@@ -809,7 +809,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("Updated config/routes.rb")
+            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
             expected_action = <<~CODE
               # frozen_string_literal: true
@@ -826,7 +826,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             CODE
             expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-            expect(output).to include("Created app/actions/users/update.rb")
+            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
 
             expect(fs.exist?("app/views/users/update.rb")).to be(false)
             expect(fs.exist?("app/templates/users/update.html.erb")).to be(false)
@@ -871,7 +871,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("Updated config/routes.rb")
+              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -888,7 +888,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-              expect(output).to include("Created app/actions/users/update.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
 
               expected_view = <<~CODE
                 # frozen_string_literal: true
@@ -903,14 +903,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/views/users/update.rb")).to eq(expected_view)
-              expect(output).to include("Created app/views/users/update.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/update.rb")
 
               expected_template = <<~EXPECTED
                 <h1>#{inflector.camelize(app)}::Views::Users::Update</h1>
               EXPECTED
 
               expect(fs.read("app/templates/users/update.html.erb")).to eq(expected_template)
-              expect(output).to include("Created app/templates/users/update.html.erb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/update.html.erb")
             end
           end
 
@@ -948,7 +948,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("Updated config/routes.rb")
+              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -966,7 +966,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-              expect(output).to include("Created app/actions/users/update.rb")
+              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
 
               expect(fs.exist?("app/views/users/update.rb")).to be(false)
               expect(fs.exist?("app/templates/users/update.html.erb")).to be(false)
@@ -1015,12 +1015,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # route
           expect(fs.read("config/routes.rb")).to eq(routes)
-          expect(output).to include("Updated config/routes.rb")
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
 
           # action
           expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1038,7 +1038,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
           # view
           expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(false)
@@ -1225,12 +1225,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # route
           expect(fs.read("config/routes.rb")).to eq(routes)
-          expect(output).to include("Updated config/routes.rb")
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
 
           # action
           expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1247,11 +1247,11 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
-          expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
           # view
           expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
-          expect(output).to include("Created slices/#{slice}/views/#{controller}/")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/#{controller}/")
 
           view_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1266,17 +1266,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
-          expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/#{controller}/#{action}.rb")
 
           # template
           expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
-          expect(output).to include("Created slices/#{slice}/templates/#{controller}/")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/#{controller}/")
 
           template_file = <<~EXPECTED
             <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
           EXPECTED
           expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-          expect(output).to include("Created slices/#{slice}/templates/#{controller}/#{action}.html.erb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/#{controller}/#{action}.html.erb")
         end
       end
 
@@ -1356,8 +1356,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("Updated config/routes.rb")
-            expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
 
             # action
             expected_action = <<~EXPECTED
@@ -1375,7 +1375,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             EXPECTED
             expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(expected_action)
-            expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
+            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
             # view
             expect(output).to_not include("Created slices/#{slice}/views/#{controller}/#{action}.rb")

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         within_application_directory do
           generate_action
 
-          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
+          expect(output).to include("  ↻ update  config/routes.rb")
+          expect(output).to include("  ✓ create  app/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  ✓ create  app/views/#{controller}/#{action}.rb")
+          expect(output).to include("  ✓ create  app/templates/#{controller}/#{action}.html.erb")
         end
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # route
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         # action
         action_file = <<~EXPECTED
@@ -142,7 +142,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  ✓ create  app/actions/#{controller}/#{action}.rb")
 
         expect(fs.directory?("app/views/#{controller}")).to eq(false)
         expect(fs.exist?("app/views/#{controller}/#{action}.rb")).to eq(false)
@@ -177,31 +177,31 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: "users.index")
         expect(fs.read("config/routes.rb")).to match(%(get "/users", to: "users.index"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.new")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/new", to: "users.new"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.create")
         expect(fs.read("config/routes.rb")).to match(%(post "/users", to: "users.create"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.edit")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/:id/edit", to: "users.edit"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.update")
         expect(fs.read("config/routes.rb")).to match(%(patch "/users/:id", to: "users.update"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.show")
         expect(fs.read("config/routes.rb")).to match(%(get "/users/:id", to: "users.show"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         subject.call(name: "users.destroy")
         expect(fs.read("config/routes.rb")).to match(%(delete "/users/:id", to: "users.destroy"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
       end
     end
 
@@ -209,7 +209,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: "talent.apply", url_path: "/talent/apply")
         expect(fs.read("config/routes.rb")).to match(%(get "/talent/apply", to: "talent.apply"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
       end
     end
 
@@ -217,7 +217,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: action_name, url_path: "/people")
         expect(fs.read("config/routes.rb")).to match(%(get "/people", to: "users.index"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       within_application_directory do
         subject.call(name: action_name, http_method: "put")
         expect(fs.read("config/routes.rb")).to match(%(put "/users", to: "users.index"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
       end
     end
 
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         subject.call(name: action_name, skip_view: true)
 
         expect(fs.read("config/routes.rb")).to match(%(get "/api/users/thing", to: "api.users.thing"))
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         action_file = <<~EXPECTED
           # frozen_string_literal: true
@@ -256,7 +256,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/api/users/thing.rb")).to eq(action_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/api/users/thing.rb")
+        expect(output).to include("  ✓ create  app/actions/api/users/thing.rb")
       end
     end
 
@@ -337,7 +337,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # route
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+        expect(output).to include("  ↻ update  config/routes.rb")
 
         # action
         action_file = <<~EXPECTED
@@ -356,7 +356,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  ✓ create  app/actions/#{controller}/#{action}.rb")
 
         # view
         view_file = <<~EXPECTED
@@ -373,7 +373,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/views/#{controller}/#{action}.rb")).to eq(view_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
+        expect(output).to include("  ✓ create  app/views/#{controller}/#{action}.rb")
 
         # template
         expect(fs.directory?("app/templates/#{controller}")).to be(true)
@@ -383,7 +383,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
+        expect(output).to include("  ✓ create  app/templates/#{controller}/#{action}.html.erb")
       end
     end
 
@@ -394,7 +394,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           subject.call(name: action_name)
 
           expect(fs.read("config/routes.rb")).to match(%(get "/api/users/thing", to: "api.users.thing"))
-          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+          expect(output).to include("  ↻ update  config/routes.rb")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -414,7 +414,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           EXPECTED
 
           expect(fs.read("app/actions/api/users/thing.rb")).to eq(action_file)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/api/users/thing.rb")
+          expect(output).to include("  ✓ create  app/actions/api/users/thing.rb")
         end
       end
     end
@@ -457,7 +457,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/#{controller}/#{action}.rb")
+        expect(output).to include("  ✓ create  app/actions/#{controller}/#{action}.rb")
 
         # view
         view_file = <<~EXPECTED
@@ -474,7 +474,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/views/#{controller}/#{action}.rb")).to eq(view_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/#{controller}/#{action}.rb")
+        expect(output).to include("  ✓ create  app/views/#{controller}/#{action}.rb")
 
         # template
         expect(fs.directory?("app/templates/#{controller}")).to be(true)
@@ -484,7 +484,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         EXPECTED
 
         expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/#{controller}/#{action}.html.erb")
+        expect(output).to include("  ✓ create  app/templates/#{controller}/#{action}.html.erb")
       end
     end
 
@@ -569,7 +569,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+            expect(output).to include("  ↻ update  config/routes.rb")
 
             expected_action = <<~CODE
               # frozen_string_literal: true
@@ -586,7 +586,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             CODE
             expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
+            expect(output).to include("  ✓ create  app/actions/users/create.rb")
 
             expect(fs.exist?("app/views/users/create.rb")).to be(false)
             expect(fs.exist?("app/templates/users/create.html.erb")).to be(false)
@@ -631,7 +631,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+              expect(output).to include("  ↻ update  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -648,7 +648,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
+              expect(output).to include("  ✓ create  app/actions/users/create.rb")
 
               expected_view = <<~CODE
                 # frozen_string_literal: true
@@ -663,14 +663,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/views/users/create.rb")).to eq(expected_view)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/create.rb")
+              expect(output).to include("  ✓ create  app/views/users/create.rb")
 
               expected_template = <<~EXPECTED
                 <h1>#{inflector.camelize(app)}::Views::Users::Create</h1>
               EXPECTED
 
               expect(fs.read("app/templates/users/create.html.erb")).to eq(expected_template)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/create.html.erb")
+              expect(output).to include("  ✓ create  app/templates/users/create.html.erb")
             end
           end
 
@@ -708,7 +708,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+              expect(output).to include("  ↻ update  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -726,7 +726,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/create.rb")
+              expect(output).to include("  ✓ create  app/actions/users/create.rb")
 
               expect(fs.exist?("app/views/users/create.rb")).to be(false)
               expect(fs.exist?("app/templates/users/create.html.erb")).to be(false)
@@ -809,7 +809,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+            expect(output).to include("  ↻ update  config/routes.rb")
 
             expected_action = <<~CODE
               # frozen_string_literal: true
@@ -826,7 +826,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             CODE
             expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
+            expect(output).to include("  ✓ create  app/actions/users/update.rb")
 
             expect(fs.exist?("app/views/users/update.rb")).to be(false)
             expect(fs.exist?("app/templates/users/update.html.erb")).to be(false)
@@ -871,7 +871,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+              expect(output).to include("  ↻ update  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -888,7 +888,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
+              expect(output).to include("  ✓ create  app/actions/users/update.rb")
 
               expected_view = <<~CODE
                 # frozen_string_literal: true
@@ -903,14 +903,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/views/users/update.rb")).to eq(expected_view)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/update.rb")
+              expect(output).to include("  ✓ create  app/views/users/update.rb")
 
               expected_template = <<~EXPECTED
                 <h1>#{inflector.camelize(app)}::Views::Users::Update</h1>
               EXPECTED
 
               expect(fs.read("app/templates/users/update.html.erb")).to eq(expected_template)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/update.html.erb")
+              expect(output).to include("  ✓ create  app/templates/users/update.html.erb")
             end
           end
 
@@ -948,7 +948,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
               # route
               expect(fs.read("config/routes.rb")).to eq(expected_routes)
-              expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+              expect(output).to include("  ↻ update  config/routes.rb")
 
               expected_action = <<~CODE
                 # frozen_string_literal: true
@@ -966,7 +966,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 end
               CODE
               expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-              expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/actions/users/update.rb")
+              expect(output).to include("  ✓ create  app/actions/users/update.rb")
 
               expect(fs.exist?("app/views/users/update.rb")).to be(false)
               expect(fs.exist?("app/templates/users/update.html.erb")).to be(false)
@@ -1015,12 +1015,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # route
           expect(fs.read("config/routes.rb")).to eq(routes)
-          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  ↻ update  config/routes.rb")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/")
 
           # action
           expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1038,7 +1038,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
           # view
           expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(false)
@@ -1225,12 +1225,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # route
           expect(fs.read("config/routes.rb")).to eq(routes)
-          expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  ↻ update  config/routes.rb")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/")
 
           # action
           expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1247,11 +1247,11 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
+          expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
           # view
           expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/#{controller}/")
+          expect(output).to include("  ✓ create  slices/#{slice}/views/#{controller}/")
 
           view_file = <<~EXPECTED
             # frozen_string_literal: true
@@ -1266,17 +1266,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             end
           EXPECTED
           expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/#{controller}/#{action}.rb")
+          expect(output).to include("  ✓ create  slices/#{slice}/views/#{controller}/#{action}.rb")
 
           # template
           expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/#{controller}/")
+          expect(output).to include("  ✓ create  slices/#{slice}/templates/#{controller}/")
 
           template_file = <<~EXPECTED
             <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
           EXPECTED
           expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/#{controller}/#{action}.html.erb")
+          expect(output).to include("  ✓ create  slices/#{slice}/templates/#{controller}/#{action}.html.erb")
         end
       end
 
@@ -1356,8 +1356,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
             # route
             expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
-            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/")
+            expect(output).to include("  ↻ update  config/routes.rb")
+            expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/")
 
             # action
             expected_action = <<~EXPECTED
@@ -1375,7 +1375,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
               end
             EXPECTED
             expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(expected_action)
-            expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/#{controller}/#{action}.rb")
+            expect(output).to include("  ✓ create  slices/#{slice}/actions/#{controller}/#{action}.rb")
 
             # view
             expect(output).to_not include("Created slices/#{slice}/views/#{controller}/#{action}.rb")

--- a/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
-        expect(output).to include("Created app/operations/send_welcome_email.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/send_welcome_email.rb")
       end
 
       context "with existing file" do
@@ -79,7 +79,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/operations/user/mailing/send_welcome_email.rb")).to eq(component)
-        expect(output).to include("Created app/operations/user/mailing/send_welcome_email.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/user/mailing/send_welcome_email.rb")
       end
 
       context "with existing file" do
@@ -119,7 +119,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("slices/main/renderers/welcome_email.rb")).to eq(component)
-        expect(output).to include("Created slices/main/renderers/welcome_email.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/renderers/welcome_email.rb")
       end
 
       context "with existing file" do
@@ -161,7 +161,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("slices/main/renderers/user/mailing/welcome_email.rb")).to eq(component)
-        expect(output).to include("Created slices/main/renderers/user/mailing/welcome_email.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/renderers/user/mailing/welcome_email.rb")
       end
 
       context "with existing file" do
@@ -205,7 +205,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       EXPECTED
 
       expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
-      expect(output).to include("Created app/operations/send_welcome_email.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/send_welcome_email.rb")
     end
   end
 
@@ -223,7 +223,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       EXPECTED
 
       expect(fs.read("app/create_entry.rb")).to eq(component)
-      expect(output).to include("Created app/create_entry.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/create_entry.rb")
     end
 
     context "when nested" do
@@ -242,7 +242,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("Created app/services/create_entry.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
       end
     end
 
@@ -262,7 +262,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("Created app/services/create_entry.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("Created app/services/create_entry.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/send_welcome_email.rb")
+        expect(output).to include("  ✓ create  app/operations/send_welcome_email.rb")
       end
 
       context "with existing file" do
@@ -79,7 +79,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/operations/user/mailing/send_welcome_email.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/user/mailing/send_welcome_email.rb")
+        expect(output).to include("  ✓ create  app/operations/user/mailing/send_welcome_email.rb")
       end
 
       context "with existing file" do
@@ -119,7 +119,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("slices/main/renderers/welcome_email.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/renderers/welcome_email.rb")
+        expect(output).to include("  ✓ create  slices/main/renderers/welcome_email.rb")
       end
 
       context "with existing file" do
@@ -161,7 +161,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("slices/main/renderers/user/mailing/welcome_email.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/renderers/user/mailing/welcome_email.rb")
+        expect(output).to include("  ✓ create  slices/main/renderers/user/mailing/welcome_email.rb")
       end
 
       context "with existing file" do
@@ -205,7 +205,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       EXPECTED
 
       expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/operations/send_welcome_email.rb")
+      expect(output).to include("  ✓ create  app/operations/send_welcome_email.rb")
     end
   end
 
@@ -223,7 +223,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       EXPECTED
 
       expect(fs.read("app/create_entry.rb")).to eq(component)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/create_entry.rb")
+      expect(output).to include("  ✓ create  app/create_entry.rb")
     end
 
     context "when nested" do
@@ -242,7 +242,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
+        expect(output).to include("  ✓ create  app/services/create_entry.rb")
       end
     end
 
@@ -262,7 +262,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
+        expect(output).to include("  ✓ create  app/services/create_entry.rb")
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         EXPECTED
 
         expect(fs.read("app/services/create_entry.rb")).to eq(component)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/services/create_entry.rb")
+        expect(output).to include("  ✓ create  app/services/create_entry.rb")
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -40,21 +40,21 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       subject.call(name: "create_posts")
 
       expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("Created config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/migrate/20240713140600_create_posts.rb")
     end
 
     it "generates a migration for a gateway" do
       subject.call(name: "create_posts", gateway: "extra")
 
       expect(fs.read("config/db/extra_migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("Created config/db/extra_migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/extra_migrate/20240713140600_create_posts.rb")
     end
 
     it "generates a migration with underscored version of camel cased name" do
       subject.call(name: "CreatePosts")
 
       expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("Created config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/migrate/20240713140600_create_posts.rb")
     end
 
     it "raises an error if given an invalid name" do
@@ -92,7 +92,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       subject.call(name: "create_posts", slice: "main")
 
       expect(fs.read("slices/main/config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("Created slices/main/config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/config/db/migrate/20240713140600_create_posts.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -40,21 +40,21 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       subject.call(name: "create_posts")
 
       expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("✓ create  config/db/migrate/20240713140600_create_posts.rb")
     end
 
     it "generates a migration for a gateway" do
       subject.call(name: "create_posts", gateway: "extra")
 
       expect(fs.read("config/db/extra_migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/extra_migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("✓ create  config/db/extra_migrate/20240713140600_create_posts.rb")
     end
 
     it "generates a migration with underscored version of camel cased name" do
       subject.call(name: "CreatePosts")
 
       expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("✓ create  config/db/migrate/20240713140600_create_posts.rb")
     end
 
     it "raises an error if given an invalid name" do
@@ -92,7 +92,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       subject.call(name: "create_posts", slice: "main")
 
       expect(fs.read("slices/main/config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
-      expect(output).to eq("\e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/config/db/migrate/20240713140600_create_posts.rb")
+      expect(output).to eq("✓ create  slices/main/config/db/migrate/20240713140600_create_posts.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/add_book.rb")).to eq(operation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/add_book.rb")
+      expect(output).to include("  ✓ create  app/add_book.rb")
       expect(output).to include(
         "  Note: We generated a top-level operation. " \
         "To generate into a directory, add a namespace: `my_namespace.add_book`"
@@ -56,7 +56,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/admin/books/add.rb")
+      expect(output).to include("  ✓ create  app/admin/books/add.rb")
     end
 
     it "generates an operation in a deep namespace with slash separators" do
@@ -78,7 +78,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/admin/books/add.rb")
+      expect(output).to include("  ✓ create  app/admin/books/add.rb")
     end
 
     context "with existing file" do
@@ -116,7 +116,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("slices/main/add_book.rb")).to eq(operation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/add_book.rb")
+      expect(output).to include("  ✓ create  slices/main/add_book.rb")
       expect(output).to include(
         "  Note: We generated a top-level operation. " \
         "To generate into a directory, add a namespace: `my_namespace.add_book`"
@@ -143,7 +143,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("slices/main/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/admin/books/add.rb")
+      expect(output).to include("  ✓ create  slices/main/admin/books/add.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/add_book.rb")).to eq(operation_file)
-      expect(output).to include("Created app/add_book.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/add_book.rb")
       expect(output).to include(
         "  Note: We generated a top-level operation. " \
         "To generate into a directory, add a namespace: `my_namespace.add_book`"
@@ -56,7 +56,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("Created app/admin/books/add.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/admin/books/add.rb")
     end
 
     it "generates an operation in a deep namespace with slash separators" do
@@ -78,7 +78,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("app/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("Created app/admin/books/add.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/admin/books/add.rb")
     end
 
     context "with existing file" do
@@ -116,7 +116,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("slices/main/add_book.rb")).to eq(operation_file)
-      expect(output).to include("Created slices/main/add_book.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/add_book.rb")
       expect(output).to include(
         "  Note: We generated a top-level operation. " \
         "To generate into a directory, add a namespace: `my_namespace.add_book`"
@@ -143,7 +143,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       EXPECTED
 
       expect(fs.read("slices/main/admin/books/add.rb")).to eq(operation_file)
-      expect(output).to include("Created slices/main/admin/books/add.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/admin/books/add.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/part.rb")).to eq(base_part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/part.rb")
+          expect(output).to include("  ✓ create  app/views/part.rb")
 
           # part
           part = <<~EXPECTED
@@ -57,7 +57,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/parts/user.rb")).to eq(part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/parts/user.rb")
+          expect(output).to include("  ✓ create  app/views/parts/user.rb")
         end
       end
 
@@ -116,7 +116,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/parts/user.rb")).to eq(part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/parts/user.rb")
+          expect(output).to include("  ✓ create  app/views/parts/user.rb")
 
           # This is still printed because the fs.write above still prints
           # expect(output).to_not include("Created app/views/part.rb")
@@ -146,7 +146,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/part.rb")).to eq(app_base_part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/part.rb")
+          expect(output).to include("  ✓ create  app/views/part.rb")
 
           # base_part
           base_part = <<~EXPECTED
@@ -162,7 +162,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/part.rb")).to eq(base_part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/part.rb")
+          expect(output).to include("  ✓ create  slices/main/views/part.rb")
 
           # part
           part = <<~EXPECTED
@@ -180,7 +180,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/parts/user.rb")).to eq(part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/parts/user.rb")
+          expect(output).to include("  ✓ create  slices/main/views/parts/user.rb")
         end
       end
     end
@@ -222,7 +222,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/parts/user.rb")).to eq(part)
-          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/parts/user.rb")
+          expect(output).to include("  ✓ create  slices/main/views/parts/user.rb")
 
           # This is still printed because the fs.write above still prints
           # expect(output).to_not include("Created slices/main/views/part.rb")

--- a/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/part.rb")).to eq(base_part)
-          expect(output).to include("Created app/views/part.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/part.rb")
 
           # part
           part = <<~EXPECTED
@@ -57,7 +57,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/parts/user.rb")).to eq(part)
-          expect(output).to include("Created app/views/parts/user.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/parts/user.rb")
         end
       end
 
@@ -116,7 +116,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/parts/user.rb")).to eq(part)
-          expect(output).to include("Created app/views/parts/user.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/parts/user.rb")
 
           # This is still printed because the fs.write above still prints
           # expect(output).to_not include("Created app/views/part.rb")
@@ -146,7 +146,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("app/views/part.rb")).to eq(app_base_part)
-          expect(output).to include("Created app/views/part.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/part.rb")
 
           # base_part
           base_part = <<~EXPECTED
@@ -162,7 +162,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/part.rb")).to eq(base_part)
-          expect(output).to include("Created slices/main/views/part.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/part.rb")
 
           # part
           part = <<~EXPECTED
@@ -180,7 +180,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/parts/user.rb")).to eq(part)
-          expect(output).to include("Created slices/main/views/parts/user.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/parts/user.rb")
         end
       end
     end
@@ -222,7 +222,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
           EXPECTED
 
           expect(fs.read("slices/main/views/parts/user.rb")).to eq(part)
-          expect(output).to include("Created slices/main/views/parts/user.rb")
+          expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/parts/user.rb")
 
           # This is still printed because the fs.write above still prints
           # expect(output).to_not include("Created slices/main/views/part.rb")

--- a/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books.rb").read).to eq relation_file
-      expect(output).to include("Created app/relations/books.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books.rb")
     end
 
     it "generates a relation in a namespace with default separator" do
@@ -67,7 +67,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("Created app/relations/books/drafts.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books/drafts.rb")
     end
 
     it "generates an relation in a namespace with slash separators" do
@@ -88,7 +88,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books/published_books.rb").read).to eq(relation_file)
-      expect(output).to include("Created app/relations/books/published_books.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books/published_books.rb")
     end
 
     it "deletes the redundant .keep file" do
@@ -114,7 +114,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books.rb").read).to eq relation_file
-      expect(output).to include("Created app/relations/books.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books.rb")
     end
 
     context "with existing file" do
@@ -152,7 +152,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/books.rb").read).to eq(relation_file)
-      expect(output).to include("Created slices/main/relations/books.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/books.rb")
     end
 
     it "generates a relation in a nested namespace" do
@@ -173,7 +173,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/book/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("Created slices/main/relations/book/drafts.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/book/drafts.rb")
     end
 
     it "generates a relation for gateway" do
@@ -195,7 +195,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/book/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("Created slices/main/relations/book/drafts.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/book/drafts.rb")
     end
 
     context "with existing file" do
@@ -233,7 +233,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/entries.rb").read).to eq(relation_file)
-      expect(output).to include("Created app/relations/entries.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/entries.rb")
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books.rb").read).to eq relation_file
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books.rb")
+      expect(output).to include("  ✓ create  app/relations/books.rb")
     end
 
     it "generates a relation in a namespace with default separator" do
@@ -67,7 +67,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books/drafts.rb")
+      expect(output).to include("  ✓ create  app/relations/books/drafts.rb")
     end
 
     it "generates an relation in a namespace with slash separators" do
@@ -88,7 +88,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books/published_books.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books/published_books.rb")
+      expect(output).to include("  ✓ create  app/relations/books/published_books.rb")
     end
 
     it "deletes the redundant .keep file" do
@@ -114,7 +114,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/books.rb").read).to eq relation_file
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/books.rb")
+      expect(output).to include("  ✓ create  app/relations/books.rb")
     end
 
     context "with existing file" do
@@ -152,7 +152,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/books.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/books.rb")
+      expect(output).to include("  ✓ create  slices/main/relations/books.rb")
     end
 
     it "generates a relation in a nested namespace" do
@@ -173,7 +173,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/book/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/book/drafts.rb")
+      expect(output).to include("  ✓ create  slices/main/relations/book/drafts.rb")
     end
 
     it "generates a relation for gateway" do
@@ -195,7 +195,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("slices/main/relations/book/drafts.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/relations/book/drafts.rb")
+      expect(output).to include("  ✓ create  slices/main/relations/book/drafts.rb")
     end
 
     context "with existing file" do
@@ -233,7 +233,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       RUBY
 
       expect(Hanami.app.root.join("app/relations/entries.rb").read).to eq(relation_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/relations/entries.rb")
+      expect(output).to include("  ✓ create  app/relations/entries.rb")
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
         EXPECTED
 
         expect(fs.read("app/repos/book_repo.rb")).to eq(repo_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/book_repo.rb")
+        expect(output).to include("  ✓ create  app/repos/book_repo.rb")
       end
 
       it "passed through repo name if repo_ suffix is preent" do
@@ -49,7 +49,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
         EXPECTED
 
         expect(fs.read("app/repos/books_repo.rb")).to eq(repo_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books_repo.rb")
+        expect(output).to include("  ✓ create  app/repos/books_repo.rb")
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("app/repos/books/drafts_repo.rb")).to eq(repo_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books/drafts_repo.rb")
+      expect(output).to include("  ✓ create  app/repos/books/drafts_repo.rb")
     end
 
     it "generates an repo in a deep namespace with slash separators" do
@@ -92,7 +92,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("app/repos/books/published/hardcover_repo.rb")).to eq(repo_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books/published/hardcover_repo.rb")
+      expect(output).to include("  ✓ create  app/repos/books/published/hardcover_repo.rb")
     end
 
     context "with existing file" do
@@ -130,7 +130,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("slices/main/repos/book_repo.rb")).to eq(repo_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/repos/book_repo.rb")
+      expect(output).to include("  ✓ create  slices/main/repos/book_repo.rb")
     end
 
     it "generates a repo in a nested namespace" do
@@ -151,7 +151,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("slices/main/repos/book/draft_repo.rb")).to eq(repo_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/repos/book/draft_repo.rb")
+      expect(output).to include("  ✓ create  slices/main/repos/book/draft_repo.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
         EXPECTED
 
         expect(fs.read("app/repos/book_repo.rb")).to eq(repo_file)
-        expect(output).to include("Created app/repos/book_repo.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/book_repo.rb")
       end
 
       it "passed through repo name if repo_ suffix is preent" do
@@ -49,7 +49,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
         EXPECTED
 
         expect(fs.read("app/repos/books_repo.rb")).to eq(repo_file)
-        expect(output).to include("Created app/repos/books_repo.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books_repo.rb")
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("app/repos/books/drafts_repo.rb")).to eq(repo_file)
-      expect(output).to include("Created app/repos/books/drafts_repo.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books/drafts_repo.rb")
     end
 
     it "generates an repo in a deep namespace with slash separators" do
@@ -92,7 +92,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("app/repos/books/published/hardcover_repo.rb")).to eq(repo_file)
-      expect(output).to include("Created app/repos/books/published/hardcover_repo.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/repos/books/published/hardcover_repo.rb")
     end
 
     context "with existing file" do
@@ -130,7 +130,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("slices/main/repos/book_repo.rb")).to eq(repo_file)
-      expect(output).to include("Created slices/main/repos/book_repo.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/repos/book_repo.rb")
     end
 
     it "generates a repo in a nested namespace" do
@@ -151,7 +151,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       EXPECTED
 
       expect(fs.read("slices/main/repos/book/draft_repo.rb")).to eq(repo_file)
-      expect(output).to include("Created slices/main/repos/book/draft_repo.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/repos/book/draft_repo.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("config/routes.rb")).to include(routes)
-      expect(output).to include("Created config/routes.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  config/routes.rb")
 
       # Slice directory
       expect(fs.directory?("slices/#{slice}")).to be(true)
-      expect(output).to include("Created slices/#{slice}/")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/")
 
       # Action
       action = <<~CODE
@@ -65,9 +65,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("slices/#{slice}/action.rb")).to eq(action)
-      expect(output).to include("Created slices/#{slice}/action.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/action.rb")
       expect(fs.read("slices/#{slice}/actions/.keep")).to eq("")
-      expect(output).to include("Created slices/#{slice}/actions/.keep")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/.keep")
 
       # Relation
       relation = <<~EXPECTED
@@ -81,9 +81,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/relation.rb")).to eq(relation)
-      expect(output).to include("Created slices/admin/db/relation.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/relation.rb")
       expect(fs.read("slices/admin/relations/.keep")).to eq("")
-      expect(output).to include("Created slices/admin/relations/.keep")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/relations/.keep")
 
       # Repo
       repo = <<~EXPECTED
@@ -97,9 +97,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/repo.rb")).to eq(repo)
-      expect(output).to include("Created slices/admin/db/repo.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/repo.rb")
       expect(fs.read("slices/admin/repos/.keep")).to eq("")
-      expect(output).to include("Created slices/admin/repos/.keep")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/repos/.keep")
 
       # Struct
       struct = <<~EXPECTED
@@ -113,9 +113,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/struct.rb")).to eq(struct)
-      expect(output).to include("Created slices/admin/db/struct.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/struct.rb")
       expect(fs.read("slices/admin/structs/.keep")).to eq("")
-      expect(output).to include("Created slices/admin/structs/.keep")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/structs/.keep")
 
       view = <<~RUBY
         # auto_register: false
@@ -127,7 +127,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/view.rb")).to eq(view)
-      expect(output).to include("Created slices/#{slice}/view.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/view.rb")
 
       helpers = <<~RUBY
         # auto_register: false
@@ -142,7 +142,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/views/helpers.rb")).to eq(helpers)
-      expect(output).to include("Created slices/#{slice}/views/helpers.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/helpers.rb")
 
       operation = <<~RUBY
         # auto_register: false
@@ -154,7 +154,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/operation.rb")).to eq(operation)
-      expect(output).to include("Created slices/#{slice}/operation.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/operation.rb")
 
       layout = <<~ERB
         <!DOCTYPE html>
@@ -173,14 +173,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         </html>
       ERB
       expect(fs.read("slices/#{slice}/templates/layouts/app.html.erb")).to eq(layout)
-      expect(output).to include("Created slices/#{slice}/templates/layouts/app.html.erb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/layouts/app.html.erb")
 
       # slices/admin/assets/js/app.js
       app_js = <<~EXPECTED
         import "../css/app.css";
       EXPECTED
       expect(fs.read("slices/#{slice}/assets/js/app.js")).to eq(app_js)
-      expect(output).to include("Created slices/#{slice}/assets/js/app.js")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/assets/js/app.js")
 
       # slices/admin/assets/css/app.css
       app_css = <<~EXPECTED
@@ -191,7 +191,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         }
       EXPECTED
       expect(fs.read("slices/#{slice}/assets/css/app.css")).to eq(app_css)
-      expect(output).to include("Created slices/#{slice}/assets/css/app.css")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/assets/css/app.css")
 
       # slices/admin/assets/images/favicon.ico
       expect(fs.exist?("slices/#{slice}/assets/images/favicon.ico")).to be(true)
@@ -228,7 +228,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
   it "generates multiple slices over time" do
     within_application_directory do
       subject.call(name: "admin")
-      expect(output).to include("Created config/routes.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  config/routes.rb")
 
       subject.call(name: "billing")
 
@@ -252,7 +252,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("config/routes.rb")).to eq(routes)
-      expect(output).to include("Updated config/routes.rb")
+      expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("config/routes.rb")).to include(routes)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  config/routes.rb")
+      expect(output).to include("  ✓ create  config/routes.rb")
 
       # Slice directory
       expect(fs.directory?("slices/#{slice}")).to be(true)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/")
+      expect(output).to include("  ✓ create  slices/#{slice}/")
 
       # Action
       action = <<~CODE
@@ -65,9 +65,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("slices/#{slice}/action.rb")).to eq(action)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/action.rb")
+      expect(output).to include("  ✓ create  slices/#{slice}/action.rb")
       expect(fs.read("slices/#{slice}/actions/.keep")).to eq("")
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/actions/.keep")
+      expect(output).to include("  ✓ create  slices/#{slice}/actions/.keep")
 
       # Relation
       relation = <<~EXPECTED
@@ -81,9 +81,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/relation.rb")).to eq(relation)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/relation.rb")
+      expect(output).to include("  ✓ create  slices/admin/db/relation.rb")
       expect(fs.read("slices/admin/relations/.keep")).to eq("")
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/relations/.keep")
+      expect(output).to include("  ✓ create  slices/admin/relations/.keep")
 
       # Repo
       repo = <<~EXPECTED
@@ -97,9 +97,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/repo.rb")).to eq(repo)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/repo.rb")
+      expect(output).to include("  ✓ create  slices/admin/db/repo.rb")
       expect(fs.read("slices/admin/repos/.keep")).to eq("")
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/repos/.keep")
+      expect(output).to include("  ✓ create  slices/admin/repos/.keep")
 
       # Struct
       struct = <<~EXPECTED
@@ -113,9 +113,9 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       EXPECTED
       expect(fs.read("slices/admin/db/struct.rb")).to eq(struct)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/db/struct.rb")
+      expect(output).to include("  ✓ create  slices/admin/db/struct.rb")
       expect(fs.read("slices/admin/structs/.keep")).to eq("")
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/admin/structs/.keep")
+      expect(output).to include("  ✓ create  slices/admin/structs/.keep")
 
       view = <<~RUBY
         # auto_register: false
@@ -127,7 +127,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/view.rb")).to eq(view)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/view.rb")
+      expect(output).to include("  ✓ create  slices/#{slice}/view.rb")
 
       helpers = <<~RUBY
         # auto_register: false
@@ -142,7 +142,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/views/helpers.rb")).to eq(helpers)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/views/helpers.rb")
+      expect(output).to include("  ✓ create  slices/#{slice}/views/helpers.rb")
 
       operation = <<~RUBY
         # auto_register: false
@@ -154,7 +154,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         end
       RUBY
       expect(fs.read("slices/#{slice}/operation.rb")).to eq(operation)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/operation.rb")
+      expect(output).to include("  ✓ create  slices/#{slice}/operation.rb")
 
       layout = <<~ERB
         <!DOCTYPE html>
@@ -173,14 +173,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         </html>
       ERB
       expect(fs.read("slices/#{slice}/templates/layouts/app.html.erb")).to eq(layout)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/templates/layouts/app.html.erb")
+      expect(output).to include("  ✓ create  slices/#{slice}/templates/layouts/app.html.erb")
 
       # slices/admin/assets/js/app.js
       app_js = <<~EXPECTED
         import "../css/app.css";
       EXPECTED
       expect(fs.read("slices/#{slice}/assets/js/app.js")).to eq(app_js)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/assets/js/app.js")
+      expect(output).to include("  ✓ create  slices/#{slice}/assets/js/app.js")
 
       # slices/admin/assets/css/app.css
       app_css = <<~EXPECTED
@@ -191,7 +191,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         }
       EXPECTED
       expect(fs.read("slices/#{slice}/assets/css/app.css")).to eq(app_css)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/#{slice}/assets/css/app.css")
+      expect(output).to include("  ✓ create  slices/#{slice}/assets/css/app.css")
 
       # slices/admin/assets/images/favicon.ico
       expect(fs.exist?("slices/#{slice}/assets/images/favicon.ico")).to be(true)
@@ -228,7 +228,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
   it "generates multiple slices over time" do
     within_application_directory do
       subject.call(name: "admin")
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  config/routes.rb")
+      expect(output).to include("  ✓ create  config/routes.rb")
 
       subject.call(name: "billing")
 
@@ -252,7 +252,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
       CODE
 
       expect(fs.read("config/routes.rb")).to eq(routes)
-      expect(output).to include("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+      expect(output).to include("  ↻ update  config/routes.rb")
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book.rb")).to eq(struct_file)
-      expect(output).to include("Created app/structs/book.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book.rb")
     end
 
     it "generates a struct in a namespace with default separator" do
@@ -48,7 +48,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book/book_draft.rb")).to eq(struct_file)
-      expect(output).to include("Created app/structs/book/book_draft.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book/book_draft.rb")
     end
 
     it "generates an struct in a deep namespace with slash separators" do
@@ -70,7 +70,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book/published/hardcover.rb")).to eq(struct_file)
-      expect(output).to include("Created app/structs/book/published/hardcover.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book/published/hardcover.rb")
     end
 
     context "with existing file" do
@@ -108,7 +108,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("slices/main/structs/book.rb")).to eq(struct_file)
-      expect(output).to include("Created slices/main/structs/book.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/structs/book.rb")
     end
 
     it "generates a struct in a nested namespace" do
@@ -129,7 +129,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("slices/main/structs/book/draft_book.rb")).to eq(struct_file)
-      expect(output).to include("Created slices/main/structs/book/draft_book.rb")
+      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/structs/book/draft_book.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book.rb")).to eq(struct_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book.rb")
+      expect(output).to include("  ✓ create  app/structs/book.rb")
     end
 
     it "generates a struct in a namespace with default separator" do
@@ -48,7 +48,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book/book_draft.rb")).to eq(struct_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book/book_draft.rb")
+      expect(output).to include("  ✓ create  app/structs/book/book_draft.rb")
     end
 
     it "generates an struct in a deep namespace with slash separators" do
@@ -70,7 +70,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("app/structs/book/published/hardcover.rb")).to eq(struct_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/structs/book/published/hardcover.rb")
+      expect(output).to include("  ✓ create  app/structs/book/published/hardcover.rb")
     end
 
     context "with existing file" do
@@ -108,7 +108,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("slices/main/structs/book.rb")).to eq(struct_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/structs/book.rb")
+      expect(output).to include("  ✓ create  slices/main/structs/book.rb")
     end
 
     it "generates a struct in a nested namespace" do
@@ -129,7 +129,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       EXPECTED
 
       expect(fs.read("slices/main/structs/book/draft_book.rb")).to eq(struct_file)
-      expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/structs/book/draft_book.rb")
+      expect(output).to include("  ✓ create  slices/main/structs/book/draft_book.rb")
     end
 
     context "with existing file" do

--- a/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/views/users/index.rb")).to eq(view_file)
-        expect(output).to include("Created app/views/users/index.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/index.rb")
 
         # template
         expect(fs.directory?("app/templates/users")).to be(true)
@@ -55,7 +55,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/templates/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("Created app/templates/users/index.html.erb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/index.html.erb")
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/views/special/users/index.rb")).to eq(view_file)
-        expect(output).to include("Created app/views/special/users/index.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/special/users/index.rb")
 
         # template
         expect(fs.directory?("app/templates/special/users")).to be(true)
@@ -90,7 +90,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/templates/special/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("Created app/templates/special/users/index.html.erb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/special/users/index.html.erb")
       end
     end
 
@@ -156,7 +156,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("slices/main/views/users/index.rb")).to eq(view_file)
-        expect(output).to include("Created slices/main/views/users/index.rb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/users/index.rb")
 
         # template
         expect(fs.directory?("slices/main/templates/users")).to be(true)
@@ -166,7 +166,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("slices/main/templates/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("Created slices/main/templates/users/index.html.erb")
+        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/templates/users/index.html.erb")
       end
     end
 

--- a/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/views/users/index.rb")).to eq(view_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/users/index.rb")
+        expect(output).to include("  ✓ create  app/views/users/index.rb")
 
         # template
         expect(fs.directory?("app/templates/users")).to be(true)
@@ -55,7 +55,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/templates/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/users/index.html.erb")
+        expect(output).to include("  ✓ create  app/templates/users/index.html.erb")
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/views/special/users/index.rb")).to eq(view_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/views/special/users/index.rb")
+        expect(output).to include("  ✓ create  app/views/special/users/index.rb")
 
         # template
         expect(fs.directory?("app/templates/special/users")).to be(true)
@@ -90,7 +90,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("app/templates/special/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/templates/special/users/index.html.erb")
+        expect(output).to include("  ✓ create  app/templates/special/users/index.html.erb")
       end
     end
 
@@ -156,7 +156,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("slices/main/views/users/index.rb")).to eq(view_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/views/users/index.rb")
+        expect(output).to include("  ✓ create  slices/main/views/users/index.rb")
 
         # template
         expect(fs.directory?("slices/main/templates/users")).to be(true)
@@ -166,7 +166,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         EXPECTED
 
         expect(fs.read("slices/main/templates/users/index.html.erb")).to eq(template_file)
-        expect(output).to include("  \e[32m✓\e[0m \e[32mcreate\e[0m  slices/main/templates/users/index.html.erb")
+        expect(output).to include("  ✓ create  slices/main/templates/users/index.html.erb")
       end
     end
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -102,11 +102,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include("Created #{app}/")
-    expect(output).to include("-> Within #{app}/")
-    expect(output).to include("Running bundle install...")
-    expect(output).to include("Running npm install...")
-    expect(output).to include("Running hanami install...")
+    expect(output).to include(Hanami::CLI::Formatter.created_directory("#{app}/"))
+    expect(output).to include("-> Entering `#{app}/` directory...")
+    expect(output).to include(Hanami::CLI::Formatter.info("Installing dependencies..."))
+    expect(output).to include(Hanami::CLI::Formatter.info("Installing npm packages..."))
+    expect(output).to include(Hanami::CLI::Formatter.info("Running hanami install..."))
 
     fs.chdir(app) do
       # .gitignore
@@ -120,7 +120,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         db/*.sqlite
       EXPECTED
       expect(fs.read(".gitignore")).to eq(gitignore)
-      expect(output).to include("Created .gitignore")
+      expect(output).to include(Hanami::CLI::Formatter.created(".gitignore"))
 
       # .env
       env = <<~EXPECTED
@@ -128,7 +128,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         DATABASE_URL=sqlite://db/#{app}.sqlite
       EXPECTED
       expect(fs.read(".env")).to eq(env)
-      expect(output).to include("Created .env")
+      expect(output).to include(Hanami::CLI::Formatter.created(".env"))
 
       # README.md
       readme = <<~EXPECTED
@@ -149,7 +149,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         - [Hanami API Doc](https://gemdocs.org/gems/hanami/latest)
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
-      expect(output).to include("Created README.md")
+      expect(output).to include(Hanami::CLI::Formatter.created("README.md"))
 
       # Gemfile
       hanami_version = Hanami::CLI::Generators::Version.gem_requirement
@@ -189,7 +189,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("Gemfile")).to eq(gemfile)
-      expect(output).to include("Created Gemfile")
+      expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
 
       # package.json
       hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
@@ -204,7 +204,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         }
       EXPECTED
       expect(fs.read("package.json")).to eq(package_json)
-      expect(output).to include("Created package.json")
+      expect(output).to include(Hanami::CLI::Formatter.created("package.json"))
 
       # Procfile.dev
       procfile = <<~EXPECTED
@@ -212,7 +212,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         assets: bundle exec hanami assets watch
       EXPECTED
       expect(fs.read("Procfile.dev")).to eq(procfile)
-      expect(output).to include("Created Procfile.dev")
+      expect(output).to include(Hanami::CLI::Formatter.created("Procfile.dev"))
 
       # Rakefile
       rakefile = <<~EXPECTED
@@ -224,7 +224,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         Rake.add_rakelib "lib/tasks"
       EXPECTED
       expect(fs.read("Rakefile")).to eq(rakefile)
-      expect(output).to include("Created Rakefile")
+      expect(output).to include(Hanami::CLI::Formatter.created("Rakefile"))
 
       # config.ru
       config_ru = <<~EXPECTED
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         run Hanami.app
       EXPECTED
       expect(fs.read("config.ru")).to eq(config_ru)
-      expect(output).to include("Created config.ru")
+      expect(output).to include(Hanami::CLI::Formatter.created("config.ru"))
 
       # bin/dev
       bin_dev = <<~EXPECTED
@@ -250,7 +250,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       EXPECTED
       expect(fs.read("bin/dev")).to eq(bin_dev)
       expect(fs.executable?("bin/dev")).to be(true)
-      expect(output).to include("Created bin/dev")
+      expect(output).to include(Hanami::CLI::Formatter.created("bin/dev"))
 
       # config/app.rb
       hanami_app = <<~EXPECTED
@@ -264,7 +264,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/app.rb")).to eq(hanami_app)
-      expect(output).to include("Created config/app.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("config/app.rb"))
 
       # config/assets.js
       assets = <<~EXPECTED
@@ -287,7 +287,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         });
       EXPECTED
       expect(fs.read("config/assets.js")).to eq(assets)
-      expect(output).to include("Created config/assets.js")
+      expect(output).to include(Hanami::CLI::Formatter.created("config/assets.js"))
 
       # config/settings.rb
       settings = <<~EXPECTED
@@ -302,7 +302,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/settings.rb")).to eq(settings)
-      expect(output).to include("Created config/settings.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("config/settings.rb"))
 
       # config/routes.rb
       routes = <<~EXPECTED
@@ -315,7 +315,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/routes.rb")).to eq(routes)
-      expect(output).to include("Created config/routes.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("config/routes.rb"))
 
       # config/puma.rb
       puma = <<~EXPECTED
@@ -368,13 +368,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/puma.rb")).to eq(puma)
-      expect(output).to include("Created config/puma.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("config/puma.rb"))
 
       # lib/tasks/.keep
       tasks_keep = <<~EXPECTED
       EXPECTED
       expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-      expect(output).to include("Created lib/tasks/.keep")
+      expect(output).to include(Hanami::CLI::Formatter.created("lib/tasks/.keep"))
 
       # app/action.rb
       action = <<~EXPECTED
@@ -392,7 +392,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("app/action.rb")).to eq(action)
-      expect(output).to include("Created app/action.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/action.rb"))
 
       # app/view.rb
       view = <<~RUBY
@@ -407,7 +407,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       RUBY
       expect(fs.read("app/view.rb")).to eq(view)
-      expect(output).to include("Created app/view.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/view.rb"))
 
       # app/views/helpers.rb
       helpers = <<~RUBY
@@ -423,7 +423,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       RUBY
       expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-      expect(output).to include("Created app/views/helpers.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/views/helpers.rb"))
 
       # app/templates/layouts/app.html.erb
       layout = <<~ERB
@@ -443,14 +443,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         </html>
       ERB
       expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-      expect(output).to include("Created app/templates/layouts/app.html.erb")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/templates/layouts/app.html.erb"))
 
       # app/assets/js/app.js
       app_js = <<~EXPECTED
         import "../css/app.css";
       EXPECTED
       expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-      expect(output).to include("Created app/assets/js/app.js")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/assets/js/app.js"))
 
       # app/assets/css/app.css
       app_css = <<~EXPECTED
@@ -461,7 +461,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         }
       EXPECTED
       expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-      expect(output).to include("Created app/assets/css/app.css")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/assets/css/app.css"))
 
       # app/assets/images/favicon.ico
       expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
@@ -481,7 +481,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-      expect(output).to include("Created lib/bookshelf/types.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("lib/bookshelf/types.rb"))
 
       # app/operation.rb
       action = <<~EXPECTED
@@ -496,7 +496,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("app/operation.rb")).to eq(action)
-      expect(output).to include("Created app/operation.rb")
+      expect(output).to include(Hanami::CLI::Formatter.created("app/operation.rb"))
 
       # public/ error pages
       expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
@@ -563,7 +563,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
-        expect(output).to include("Created Gemfile")
+        expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
       end
     end
   end
@@ -587,11 +587,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       subject.call(app: app, **kwargs)
 
       expect(fs.directory?(app)).to be(true)
-      expect(output).to include("Created #{app}/")
-      expect(output).to include("-> Within #{app}/")
-      expect(output).to include("Running bundle install...")
-      expect(output).to include("Running npm install...")
-      expect(output).to include("Running hanami install...")
+      expect(output).to include(Hanami::CLI::Formatter.created_directory("#{app}/"))
+      expect(output).to include("-> Entering `#{app}/` directory...")
+      expect(output).to include(Hanami::CLI::Formatter.info("Installing dependencies..."))
+      expect(output).to include(Hanami::CLI::Formatter.info("Installing npm packages..."))
+      expect(output).to include(Hanami::CLI::Formatter.info("Running hanami install..."))
 
       fs.chdir(app) do
         # .gitignore
@@ -605,7 +605,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           db/*.sqlite
         EXPECTED
         expect(fs.read(".gitignore")).to eq(gitignore)
-        expect(output).to include("Created .gitignore")
+        expect(output).to include(Hanami::CLI::Formatter.created(".gitignore"))
 
         # .env
         env = <<~EXPECTED
@@ -613,7 +613,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           DATABASE_URL=sqlite://db/#{app}.sqlite
         EXPECTED
         expect(fs.read(".env")).to eq(env)
-        expect(output).to include("Created .env")
+        expect(output).to include(Hanami::CLI::Formatter.created(".env"))
 
         # README.md
         readme = <<~EXPECTED
@@ -634,7 +634,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           - [Hanami API Doc](https://gemdocs.org/gems/hanami/latest)
         EXPECTED
         expect(fs.read("README.md")).to eq(readme)
-        expect(output).to include("Created README.md")
+        expect(output).to include(Hanami::CLI::Formatter.created("README.md"))
 
         # Gemfile
         hanami_version = Hanami::CLI::Generators::Version.gem_requirement
@@ -674,7 +674,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
-        expect(output).to include("Created Gemfile")
+        expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
 
         # package.json
         hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
@@ -689,7 +689,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           }
         EXPECTED
         expect(fs.read("package.json")).to eq(package_json)
-        expect(output).to include("Created package.json")
+        expect(output).to include(Hanami::CLI::Formatter.created("package.json"))
 
         # Procfile.dev
         procfile = <<~EXPECTED
@@ -697,7 +697,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           assets: bundle exec hanami assets watch
         EXPECTED
         expect(fs.read("Procfile.dev")).to eq(procfile)
-        expect(output).to include("Created Procfile.dev")
+        expect(output).to include(Hanami::CLI::Formatter.created("Procfile.dev"))
 
         # Rakefile
         rakefile = <<~EXPECTED
@@ -709,7 +709,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           Rake.add_rakelib "lib/tasks"
         EXPECTED
         expect(fs.read("Rakefile")).to eq(rakefile)
-        expect(output).to include("Created Rakefile")
+        expect(output).to include(Hanami::CLI::Formatter.created("Rakefile"))
 
         # config.ru
         config_ru = <<~EXPECTED
@@ -720,7 +720,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           run Hanami.app
         EXPECTED
         expect(fs.read("config.ru")).to eq(config_ru)
-        expect(output).to include("Created config.ru")
+        expect(output).to include(Hanami::CLI::Formatter.created("config.ru"))
 
         # bin/dev
         bin_dev = <<~EXPECTED
@@ -735,7 +735,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("bin/dev")).to eq(bin_dev)
         expect(fs.executable?("bin/dev")).to be(true)
-        expect(output).to include("Created bin/dev")
+        expect(output).to include(Hanami::CLI::Formatter.created("bin/dev"))
 
         # config/app.rb
         hanami_app = <<~EXPECTED
@@ -749,7 +749,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/app.rb")).to eq(hanami_app)
-        expect(output).to include("Created config/app.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/app.rb"))
 
         # config/assets.js
         assets = <<~EXPECTED
@@ -772,7 +772,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           });
         EXPECTED
         expect(fs.read("config/assets.js")).to eq(assets)
-        expect(output).to include("Created config/assets.js")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/assets.js"))
 
         # config/settings.rb
         settings = <<~EXPECTED
@@ -787,7 +787,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/settings.rb")).to eq(settings)
-        expect(output).to include("Created config/settings.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/settings.rb"))
 
         # config/routes.rb
         routes = <<~EXPECTED
@@ -800,7 +800,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("Created config/routes.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/routes.rb"))
 
         # config/puma.rb
         puma = <<~EXPECTED
@@ -853,13 +853,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/puma.rb")).to eq(puma)
-        expect(output).to include("Created config/puma.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/puma.rb"))
 
         # lib/tasks/.keep
         tasks_keep = <<~EXPECTED
         EXPECTED
         expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-        expect(output).to include("Created lib/tasks/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("lib/tasks/.keep"))
 
         # app/action.rb
         action = <<~EXPECTED
@@ -877,9 +877,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/action.rb")).to eq(action)
-        expect(output).to include("Created app/action.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/action.rb"))
         expect(fs.read("app/actions/.keep")).to eq("")
-        expect(output).to include("Created app/actions/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/actions/.keep"))
 
         # app/view.rb
         view = <<~RUBY
@@ -894,7 +894,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         RUBY
         expect(fs.read("app/view.rb")).to eq(view)
-        expect(output).to include("Created app/view.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/view.rb"))
 
         # app/views/helpers.rb
         helpers = <<~RUBY
@@ -910,7 +910,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         RUBY
         expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-        expect(output).to include("Created app/views/helpers.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/views/helpers.rb"))
 
         # app/templates/layouts/app.html.erb
         layout = <<~ERB
@@ -930,14 +930,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           </html>
         ERB
         expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-        expect(output).to include("Created app/templates/layouts/app.html.erb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/templates/layouts/app.html.erb"))
 
         # app/assets/js/app.js
         app_js = <<~EXPECTED
           import "../css/app.css";
         EXPECTED
         expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-        expect(output).to include("Created app/assets/js/app.js")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/assets/js/app.js"))
 
         # app/assets/css/app.css
         app_css = <<~EXPECTED
@@ -948,7 +948,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           }
         EXPECTED
         expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-        expect(output).to include("Created app/assets/css/app.css")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/assets/css/app.css"))
 
         # app/assets/images/favicon.ico
         expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
@@ -967,9 +967,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/relation.rb")).to eq(relation)
-        expect(output).to include("Created app/db/relation.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/db/relation.rb"))
         expect(fs.read("app/relations/.keep")).to eq("")
-        expect(output).to include("Created app/relations/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/relations/.keep"))
 
         # app/db/repo.rb
         repo = <<~EXPECTED
@@ -985,9 +985,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/repo.rb")).to eq(repo)
-        expect(output).to include("Created app/db/repo.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/db/repo.rb"))
         expect(fs.read("app/repos/.keep")).to eq("")
-        expect(output).to include("Created app/repos/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/repos/.keep"))
 
         # app/db/struct.rb
         struct = <<~EXPECTED
@@ -1003,9 +1003,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/struct.rb")).to eq(struct)
-        expect(output).to include("Created app/db/struct.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/db/struct.rb"))
         expect(fs.read("app/structs/.keep")).to eq("")
-        expect(output).to include("Created app/structs/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("app/structs/.keep"))
 
         seeds = <<~EXPECTED
           # This seeds file should create the database records required to run the app.
@@ -1025,13 +1025,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           #   categories.insert(title: "General")
         EXPECTED
         expect(fs.read("config/db/seeds.rb")).to eq(seeds)
-        expect(output).to include("Created config/db/seeds.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/db/seeds.rb"))
 
         expect(fs.read("config/db/migrate/.keep")).to eq("")
-        expect(output).to include("Created config/db/migrate/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("config/db/migrate/.keep"))
 
         expect(fs.read("db/.keep")).to eq("")
-        expect(output).to include("Created db/.keep")
+        expect(output).to include(Hanami::CLI::Formatter.created("db/.keep"))
 
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
@@ -1048,7 +1048,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-        expect(output).to include("Created lib/bookshelf/types.rb")
+        expect(output).to include(Hanami::CLI::Formatter.created("lib/bookshelf/types.rb"))
 
         # public/ error pages
         expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
@@ -1412,7 +1412,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include("Running bundle binstubs hanami-cli rake...")
+    expect(output).to include(Hanami::CLI::Formatter.info("Running bundle binstubs hanami-cli rake..."))
   end
 
   it "initializes a git repository" do
@@ -1438,6 +1438,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include("Initializing git repository...")
+    expect(output).to include(Hanami::CLI::Formatter.info("Initializing git repository..."))
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -102,11 +102,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include(Hanami::CLI::Formatter.created_directory("#{app}/"))
+    expect(output).to include("✓ create directory  #{app}/")
     expect(output).to include("-> Entering `#{app}/` directory...")
-    expect(output).to include(Hanami::CLI::Formatter.info("Installing dependencies..."))
-    expect(output).to include(Hanami::CLI::Formatter.info("Installing npm packages..."))
-    expect(output).to include(Hanami::CLI::Formatter.info("Running hanami install..."))
+    expect(output).to include("→ Installing dependencies...")
+    expect(output).to include("→ Installing npm packages...")
+    expect(output).to include("→ Running hanami install...")
 
     fs.chdir(app) do
       # .gitignore
@@ -120,7 +120,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         db/*.sqlite
       EXPECTED
       expect(fs.read(".gitignore")).to eq(gitignore)
-      expect(output).to include(Hanami::CLI::Formatter.created(".gitignore"))
+      expect(output).to include("  ✓ create  .gitignore")
 
       # .env
       env = <<~EXPECTED
@@ -128,7 +128,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         DATABASE_URL=sqlite://db/#{app}.sqlite
       EXPECTED
       expect(fs.read(".env")).to eq(env)
-      expect(output).to include(Hanami::CLI::Formatter.created(".env"))
+      expect(output).to include("  ✓ create  .env")
 
       # README.md
       readme = <<~EXPECTED
@@ -149,7 +149,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         - [Hanami API Doc](https://gemdocs.org/gems/hanami/latest)
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
-      expect(output).to include(Hanami::CLI::Formatter.created("README.md"))
+      expect(output).to include("  ✓ create  README.md")
 
       # Gemfile
       hanami_version = Hanami::CLI::Generators::Version.gem_requirement
@@ -189,7 +189,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("Gemfile")).to eq(gemfile)
-      expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
+      expect(output).to include("  ✓ create  Gemfile")
 
       # package.json
       hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
@@ -204,7 +204,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         }
       EXPECTED
       expect(fs.read("package.json")).to eq(package_json)
-      expect(output).to include(Hanami::CLI::Formatter.created("package.json"))
+      expect(output).to include("  ✓ create  package.json")
 
       # Procfile.dev
       procfile = <<~EXPECTED
@@ -212,7 +212,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         assets: bundle exec hanami assets watch
       EXPECTED
       expect(fs.read("Procfile.dev")).to eq(procfile)
-      expect(output).to include(Hanami::CLI::Formatter.created("Procfile.dev"))
+      expect(output).to include("  ✓ create  Procfile.dev")
 
       # Rakefile
       rakefile = <<~EXPECTED
@@ -224,7 +224,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         Rake.add_rakelib "lib/tasks"
       EXPECTED
       expect(fs.read("Rakefile")).to eq(rakefile)
-      expect(output).to include(Hanami::CLI::Formatter.created("Rakefile"))
+      expect(output).to include("  ✓ create  Rakefile")
 
       # config.ru
       config_ru = <<~EXPECTED
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         run Hanami.app
       EXPECTED
       expect(fs.read("config.ru")).to eq(config_ru)
-      expect(output).to include(Hanami::CLI::Formatter.created("config.ru"))
+      expect(output).to include("  ✓ create  config.ru")
 
       # bin/dev
       bin_dev = <<~EXPECTED
@@ -250,7 +250,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       EXPECTED
       expect(fs.read("bin/dev")).to eq(bin_dev)
       expect(fs.executable?("bin/dev")).to be(true)
-      expect(output).to include(Hanami::CLI::Formatter.created("bin/dev"))
+      expect(output).to include("  ✓ create  bin/dev")
 
       # config/app.rb
       hanami_app = <<~EXPECTED
@@ -264,7 +264,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/app.rb")).to eq(hanami_app)
-      expect(output).to include(Hanami::CLI::Formatter.created("config/app.rb"))
+      expect(output).to include("  ✓ create  config/app.rb")
 
       # config/assets.js
       assets = <<~EXPECTED
@@ -287,7 +287,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         });
       EXPECTED
       expect(fs.read("config/assets.js")).to eq(assets)
-      expect(output).to include(Hanami::CLI::Formatter.created("config/assets.js"))
+      expect(output).to include("  ✓ create  config/assets.js")
 
       # config/settings.rb
       settings = <<~EXPECTED
@@ -302,7 +302,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/settings.rb")).to eq(settings)
-      expect(output).to include(Hanami::CLI::Formatter.created("config/settings.rb"))
+      expect(output).to include("  ✓ create  config/settings.rb")
 
       # config/routes.rb
       routes = <<~EXPECTED
@@ -315,7 +315,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/routes.rb")).to eq(routes)
-      expect(output).to include(Hanami::CLI::Formatter.created("config/routes.rb"))
+      expect(output).to include("  ✓ create  config/routes.rb")
 
       # config/puma.rb
       puma = <<~EXPECTED
@@ -368,13 +368,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("config/puma.rb")).to eq(puma)
-      expect(output).to include(Hanami::CLI::Formatter.created("config/puma.rb"))
+      expect(output).to include("  ✓ create  config/puma.rb")
 
       # lib/tasks/.keep
       tasks_keep = <<~EXPECTED
       EXPECTED
       expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-      expect(output).to include(Hanami::CLI::Formatter.created("lib/tasks/.keep"))
+      expect(output).to include("  ✓ create  lib/tasks/.keep")
 
       # app/action.rb
       action = <<~EXPECTED
@@ -392,7 +392,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("app/action.rb")).to eq(action)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/action.rb"))
+      expect(output).to include("  ✓ create  app/action.rb")
 
       # app/view.rb
       view = <<~RUBY
@@ -407,7 +407,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       RUBY
       expect(fs.read("app/view.rb")).to eq(view)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/view.rb"))
+      expect(output).to include("  ✓ create  app/view.rb")
 
       # app/views/helpers.rb
       helpers = <<~RUBY
@@ -423,7 +423,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       RUBY
       expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/views/helpers.rb"))
+      expect(output).to include("  ✓ create  app/views/helpers.rb")
 
       # app/templates/layouts/app.html.erb
       layout = <<~ERB
@@ -443,14 +443,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         </html>
       ERB
       expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/templates/layouts/app.html.erb"))
+      expect(output).to include("  ✓ create  app/templates/layouts/app.html.erb")
 
       # app/assets/js/app.js
       app_js = <<~EXPECTED
         import "../css/app.css";
       EXPECTED
       expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/assets/js/app.js"))
+      expect(output).to include("  ✓ create  app/assets/js/app.js")
 
       # app/assets/css/app.css
       app_css = <<~EXPECTED
@@ -461,7 +461,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         }
       EXPECTED
       expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/assets/css/app.css"))
+      expect(output).to include("  ✓ create  app/assets/css/app.css")
 
       # app/assets/images/favicon.ico
       expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
@@ -481,7 +481,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-      expect(output).to include(Hanami::CLI::Formatter.created("lib/bookshelf/types.rb"))
+      expect(output).to include("  ✓ create  lib/bookshelf/types.rb")
 
       # app/operation.rb
       action = <<~EXPECTED
@@ -496,7 +496,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("app/operation.rb")).to eq(action)
-      expect(output).to include(Hanami::CLI::Formatter.created("app/operation.rb"))
+      expect(output).to include("  ✓ create  app/operation.rb")
 
       # public/ error pages
       expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
@@ -563,7 +563,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
-        expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
+        expect(output).to include("  ✓ create  Gemfile")
       end
     end
   end
@@ -587,11 +587,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       subject.call(app: app, **kwargs)
 
       expect(fs.directory?(app)).to be(true)
-      expect(output).to include(Hanami::CLI::Formatter.created_directory("#{app}/"))
+      expect(output).to include("✓ create directory  #{app}/")
       expect(output).to include("-> Entering `#{app}/` directory...")
-      expect(output).to include(Hanami::CLI::Formatter.info("Installing dependencies..."))
-      expect(output).to include(Hanami::CLI::Formatter.info("Installing npm packages..."))
-      expect(output).to include(Hanami::CLI::Formatter.info("Running hanami install..."))
+      expect(output).to include("→ Installing dependencies...")
+      expect(output).to include("→ Installing npm packages...")
+      expect(output).to include("→ Running hanami install...")
 
       fs.chdir(app) do
         # .gitignore
@@ -605,7 +605,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           db/*.sqlite
         EXPECTED
         expect(fs.read(".gitignore")).to eq(gitignore)
-        expect(output).to include(Hanami::CLI::Formatter.created(".gitignore"))
+        expect(output).to include("  ✓ create  .gitignore")
 
         # .env
         env = <<~EXPECTED
@@ -613,7 +613,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           DATABASE_URL=sqlite://db/#{app}.sqlite
         EXPECTED
         expect(fs.read(".env")).to eq(env)
-        expect(output).to include(Hanami::CLI::Formatter.created(".env"))
+        expect(output).to include("  ✓ create  .env")
 
         # README.md
         readme = <<~EXPECTED
@@ -634,7 +634,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           - [Hanami API Doc](https://gemdocs.org/gems/hanami/latest)
         EXPECTED
         expect(fs.read("README.md")).to eq(readme)
-        expect(output).to include(Hanami::CLI::Formatter.created("README.md"))
+        expect(output).to include("  ✓ create  README.md")
 
         # Gemfile
         hanami_version = Hanami::CLI::Generators::Version.gem_requirement
@@ -674,7 +674,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
-        expect(output).to include(Hanami::CLI::Formatter.created("Gemfile"))
+        expect(output).to include("  ✓ create  Gemfile")
 
         # package.json
         hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
@@ -689,7 +689,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           }
         EXPECTED
         expect(fs.read("package.json")).to eq(package_json)
-        expect(output).to include(Hanami::CLI::Formatter.created("package.json"))
+        expect(output).to include("  ✓ create  package.json")
 
         # Procfile.dev
         procfile = <<~EXPECTED
@@ -697,7 +697,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           assets: bundle exec hanami assets watch
         EXPECTED
         expect(fs.read("Procfile.dev")).to eq(procfile)
-        expect(output).to include(Hanami::CLI::Formatter.created("Procfile.dev"))
+        expect(output).to include("  ✓ create  Procfile.dev")
 
         # Rakefile
         rakefile = <<~EXPECTED
@@ -709,7 +709,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           Rake.add_rakelib "lib/tasks"
         EXPECTED
         expect(fs.read("Rakefile")).to eq(rakefile)
-        expect(output).to include(Hanami::CLI::Formatter.created("Rakefile"))
+        expect(output).to include("  ✓ create  Rakefile")
 
         # config.ru
         config_ru = <<~EXPECTED
@@ -720,7 +720,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           run Hanami.app
         EXPECTED
         expect(fs.read("config.ru")).to eq(config_ru)
-        expect(output).to include(Hanami::CLI::Formatter.created("config.ru"))
+        expect(output).to include("  ✓ create  config.ru")
 
         # bin/dev
         bin_dev = <<~EXPECTED
@@ -735,7 +735,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("bin/dev")).to eq(bin_dev)
         expect(fs.executable?("bin/dev")).to be(true)
-        expect(output).to include(Hanami::CLI::Formatter.created("bin/dev"))
+        expect(output).to include("  ✓ create  bin/dev")
 
         # config/app.rb
         hanami_app = <<~EXPECTED
@@ -749,7 +749,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/app.rb")).to eq(hanami_app)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/app.rb"))
+        expect(output).to include("  ✓ create  config/app.rb")
 
         # config/assets.js
         assets = <<~EXPECTED
@@ -772,7 +772,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           });
         EXPECTED
         expect(fs.read("config/assets.js")).to eq(assets)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/assets.js"))
+        expect(output).to include("  ✓ create  config/assets.js")
 
         # config/settings.rb
         settings = <<~EXPECTED
@@ -787,7 +787,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/settings.rb")).to eq(settings)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/settings.rb"))
+        expect(output).to include("  ✓ create  config/settings.rb")
 
         # config/routes.rb
         routes = <<~EXPECTED
@@ -800,7 +800,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/routes.rb"))
+        expect(output).to include("  ✓ create  config/routes.rb")
 
         # config/puma.rb
         puma = <<~EXPECTED
@@ -853,13 +853,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("config/puma.rb")).to eq(puma)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/puma.rb"))
+        expect(output).to include("  ✓ create  config/puma.rb")
 
         # lib/tasks/.keep
         tasks_keep = <<~EXPECTED
         EXPECTED
         expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-        expect(output).to include(Hanami::CLI::Formatter.created("lib/tasks/.keep"))
+        expect(output).to include("  ✓ create  lib/tasks/.keep")
 
         # app/action.rb
         action = <<~EXPECTED
@@ -877,9 +877,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/action.rb")).to eq(action)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/action.rb"))
+        expect(output).to include("  ✓ create  app/action.rb")
         expect(fs.read("app/actions/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("app/actions/.keep"))
+        expect(output).to include("  ✓ create  app/actions/.keep")
 
         # app/view.rb
         view = <<~RUBY
@@ -894,7 +894,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         RUBY
         expect(fs.read("app/view.rb")).to eq(view)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/view.rb"))
+        expect(output).to include("  ✓ create  app/view.rb")
 
         # app/views/helpers.rb
         helpers = <<~RUBY
@@ -910,7 +910,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         RUBY
         expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/views/helpers.rb"))
+        expect(output).to include("  ✓ create  app/views/helpers.rb")
 
         # app/templates/layouts/app.html.erb
         layout = <<~ERB
@@ -930,14 +930,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           </html>
         ERB
         expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/templates/layouts/app.html.erb"))
+        expect(output).to include("  ✓ create  app/templates/layouts/app.html.erb")
 
         # app/assets/js/app.js
         app_js = <<~EXPECTED
           import "../css/app.css";
         EXPECTED
         expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/assets/js/app.js"))
+        expect(output).to include("  ✓ create  app/assets/js/app.js")
 
         # app/assets/css/app.css
         app_css = <<~EXPECTED
@@ -948,7 +948,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           }
         EXPECTED
         expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/assets/css/app.css"))
+        expect(output).to include("  ✓ create  app/assets/css/app.css")
 
         # app/assets/images/favicon.ico
         expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
@@ -967,9 +967,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/relation.rb")).to eq(relation)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/db/relation.rb"))
+        expect(output).to include("  ✓ create  app/db/relation.rb")
         expect(fs.read("app/relations/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("app/relations/.keep"))
+        expect(output).to include("  ✓ create  app/relations/.keep")
 
         # app/db/repo.rb
         repo = <<~EXPECTED
@@ -985,9 +985,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/repo.rb")).to eq(repo)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/db/repo.rb"))
+        expect(output).to include("  ✓ create  app/db/repo.rb")
         expect(fs.read("app/repos/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("app/repos/.keep"))
+        expect(output).to include("  ✓ create  app/repos/.keep")
 
         # app/db/struct.rb
         struct = <<~EXPECTED
@@ -1003,9 +1003,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("app/db/struct.rb")).to eq(struct)
-        expect(output).to include(Hanami::CLI::Formatter.created("app/db/struct.rb"))
+        expect(output).to include("  ✓ create  app/db/struct.rb")
         expect(fs.read("app/structs/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("app/structs/.keep"))
+        expect(output).to include("  ✓ create  app/structs/.keep")
 
         seeds = <<~EXPECTED
           # This seeds file should create the database records required to run the app.
@@ -1025,13 +1025,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           #   categories.insert(title: "General")
         EXPECTED
         expect(fs.read("config/db/seeds.rb")).to eq(seeds)
-        expect(output).to include(Hanami::CLI::Formatter.created("config/db/seeds.rb"))
+        expect(output).to include("  ✓ create  config/db/seeds.rb")
 
         expect(fs.read("config/db/migrate/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("config/db/migrate/.keep"))
+        expect(output).to include("  ✓ create  config/db/migrate/.keep")
 
         expect(fs.read("db/.keep")).to eq("")
-        expect(output).to include(Hanami::CLI::Formatter.created("db/.keep"))
+        expect(output).to include("  ✓ create  db/.keep")
 
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
@@ -1048,7 +1048,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         EXPECTED
         expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-        expect(output).to include(Hanami::CLI::Formatter.created("lib/bookshelf/types.rb"))
+        expect(output).to include("  ✓ create  lib/bookshelf/types.rb")
 
         # public/ error pages
         expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
@@ -1412,7 +1412,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include(Hanami::CLI::Formatter.info("Running bundle binstubs hanami-cli rake..."))
+    expect(output).to include("→ Running bundle binstubs hanami-cli rake...")
   end
 
   it "initializes a git repository" do
@@ -1438,6 +1438,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     subject.call(app: app, **kwargs)
 
     expect(fs.directory?(app)).to be(true)
-    expect(output).to include(Hanami::CLI::Formatter.info("Initializing git repository..."))
+    expect(output).to include("→ Initializing git repository...")
   end
 end

--- a/spec/unit/hanami/cli/formatter_spec.rb
+++ b/spec/unit/hanami/cli/formatter_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Formatter do
+  describe "COLORS" do
+    it "defines ANSI color codes" do
+      expect(described_class::COLORS).to eq({
+                                              reset: "\e[0m",
+                                              bold: "\e[1m",
+                                              green: "\e[32m",
+                                              blue: "\e[34m",
+                                              cyan: "\e[36m",
+                                              yellow: "\e[33m",
+                                              red: "\e[31m",
+                                              gray: "\e[90m"
+                                            })
+    end
+
+    it "is frozen" do
+      expect(described_class::COLORS).to be_frozen
+    end
+  end
+
+  describe "ICONS" do
+    it "defines icons for different operations" do
+      expect(described_class::ICONS).to eq({
+                                             create: "✓",
+                                             update: "↻",
+                                             info: "→",
+                                             warning: "⚠",
+                                             error: "✗",
+                                             success: "✓"
+                                           })
+    end
+
+    it "is frozen" do
+      expect(described_class::ICONS).to be_frozen
+    end
+  end
+
+  describe ".colorize" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "wraps text with color codes" do
+        result = described_class.colorize("hello", :green)
+        expect(result).to eq("\e[32mhello\e[0m")
+      end
+
+      it "handles different colors" do
+        expect(described_class.colorize("text", :red)).to eq("\e[31mtext\e[0m")
+        expect(described_class.colorize("text", :blue)).to eq("\e[34mtext\e[0m")
+        expect(described_class.colorize("text", :yellow)).to eq("\e[33mtext\e[0m")
+        expect(described_class.colorize("text", :cyan)).to eq("\e[36mtext\e[0m")
+        expect(described_class.colorize("text", :gray)).to eq("\e[90mtext\e[0m")
+        expect(described_class.colorize("text", :bold)).to eq("\e[1mtext\e[0m")
+      end
+
+      it "handles empty text" do
+        result = described_class.colorize("", :green)
+        expect(result).to eq("\e[32m\e[0m")
+      end
+
+      it "handles nil color gracefully" do
+        result = described_class.colorize("text", nil)
+        expect(result).to eq("text\e[0m")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "returns text without color codes" do
+        result = described_class.colorize("hello", :green)
+        expect(result).to eq("hello")
+      end
+
+      it "handles empty text" do
+        result = described_class.colorize("", :green)
+        expect(result).to eq("")
+      end
+    end
+  end
+
+  describe ".created" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a create message with green color and icon" do
+        result = described_class.created("app/models/user.rb")
+        expect(result).to eq("  \e[32m✓\e[0m \e[32mcreate\e[0m  app/models/user.rb")
+      end
+
+      it "handles paths with spaces" do
+        result = described_class.created("my app/user.rb")
+        expect(result).to eq("  \e[32m✓\e[0m \e[32mcreate\e[0m  my app/user.rb")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats a create message without colors" do
+        result = described_class.created("app/models/user.rb")
+        expect(result).to eq("  ✓ create  app/models/user.rb")
+      end
+    end
+  end
+
+  describe ".created_directory" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a create directory message with green color and icon" do
+        result = described_class.created_directory("app/models")
+        expect(result).to eq("\e[32m✓\e[0m \e[32mcreate directory\e[0m  app/models")
+      end
+
+      it "handles directory paths with spaces" do
+        result = described_class.created_directory("my app/models")
+        expect(result).to eq("\e[32m✓\e[0m \e[32mcreate directory\e[0m  my app/models")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats a create directory message without colors" do
+        result = described_class.created_directory("app/models")
+        expect(result).to eq("✓ create directory  app/models")
+      end
+    end
+  end
+
+  describe ".updated" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats an update message with cyan color and icon" do
+        result = described_class.updated("config/routes.rb")
+        expect(result).to eq("  \e[36m↻\e[0m \e[36mupdate\e[0m  config/routes.rb")
+      end
+
+      it "handles paths with spaces" do
+        result = described_class.updated("my config/routes.rb")
+        expect(result).to eq("  \e[36m↻\e[0m \e[36mupdate\e[0m  my config/routes.rb")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats an update message without colors" do
+        result = described_class.updated("config/routes.rb")
+        expect(result).to eq("  ↻ update  config/routes.rb")
+      end
+    end
+  end
+
+  describe ".info" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats an info message with blue color and icon" do
+        result = described_class.info("Starting server...")
+        expect(result).to eq("\e[34m→\e[0m Starting server...")
+      end
+
+      it "handles empty text" do
+        result = described_class.info("")
+        expect(result).to eq("\e[34m→\e[0m ")
+      end
+
+      it "handles multiline text" do
+        result = described_class.info("Line 1\nLine 2")
+        expect(result).to eq("\e[34m→\e[0m Line 1\nLine 2")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats an info message without colors" do
+        result = described_class.info("Starting server...")
+        expect(result).to eq("→ Starting server...")
+      end
+    end
+  end
+
+  describe ".success" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a success message with green color and icon" do
+        result = described_class.success("Application created successfully!")
+        expect(result).to eq("\e[32m✓\e[0m \e[32mApplication created successfully!\e[0m")
+      end
+
+      it "handles empty text" do
+        result = described_class.success("")
+        expect(result).to eq("\e[32m✓\e[0m \e[32m\e[0m")
+      end
+
+      it "handles multiline text" do
+        result = described_class.success("Success!\nAll done.")
+        expect(result).to eq("\e[32m✓\e[0m \e[32mSuccess!\nAll done.\e[0m")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats a success message without colors" do
+        result = described_class.success("Application created successfully!")
+        expect(result).to eq("✓ Application created successfully!")
+      end
+    end
+  end
+
+  describe ".warning" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a warning message with yellow color and icon" do
+        result = described_class.warning("This is deprecated")
+        expect(result).to eq("\e[33m⚠\e[0m \e[33mwarning\e[0m This is deprecated")
+      end
+
+      it "handles empty text" do
+        result = described_class.warning("")
+        expect(result).to eq("\e[33m⚠\e[0m \e[33mwarning\e[0m ")
+      end
+
+      it "handles multiline text" do
+        result = described_class.warning("Warning!\nBe careful.")
+        expect(result).to eq("\e[33m⚠\e[0m \e[33mwarning\e[0m Warning!\nBe careful.")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats a warning message without colors" do
+        result = described_class.warning("This is deprecated")
+        expect(result).to eq("⚠ warning This is deprecated")
+      end
+    end
+  end
+
+  describe ".error" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats an error message with red color and icon" do
+        result = described_class.error("Something went wrong")
+        expect(result).to eq("\e[31m✗\e[0m \e[31merror\e[0m Something went wrong")
+      end
+
+      it "handles empty text" do
+        result = described_class.error("")
+        expect(result).to eq("\e[31m✗\e[0m \e[31merror\e[0m ")
+      end
+
+      it "handles multiline text" do
+        result = described_class.error("Error!\nCheck the logs.")
+        expect(result).to eq("\e[31m✗\e[0m \e[31merror\e[0m Error!\nCheck the logs.")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats an error message without colors" do
+        result = described_class.error("Something went wrong")
+        expect(result).to eq("✗ error Something went wrong")
+      end
+    end
+  end
+
+  describe ".header" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a header with bold text and newline prefix" do
+        result = described_class.header("Configuration")
+        expect(result).to eq("\n\e[1mConfiguration\e[0m")
+      end
+
+      it "handles empty text" do
+        result = described_class.header("")
+        expect(result).to eq("\n\e[1m\e[0m")
+      end
+
+      it "handles multiline text" do
+        result = described_class.header("Header\nSubheader")
+        expect(result).to eq("\n\e[1mHeader\nSubheader\e[0m")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats a header without colors but with newline prefix" do
+        result = described_class.header("Configuration")
+        expect(result).to eq("\nConfiguration")
+      end
+    end
+  end
+
+  describe ".dim" do
+    it "returns the text unchanged" do
+      result = described_class.dim("secondary text")
+      expect(result).to eq("secondary text")
+    end
+
+    it "handles empty text" do
+      result = described_class.dim("")
+      expect(result).to eq("")
+    end
+
+    it "handles multiline text" do
+      result = described_class.dim("Line 1\nLine 2")
+      expect(result).to eq("Line 1\nLine 2")
+    end
+
+    it "handles nil input" do
+      result = described_class.dim(nil)
+      expect(result).to be_nil
+    end
+  end
+
+  describe "module behavior" do
+    it "is a module" do
+      expect(described_class).to be_a(Module)
+    end
+
+    it "has module_function methods" do
+      expect(described_class).to respond_to(:colorize)
+      expect(described_class).to respond_to(:created)
+      expect(described_class).to respond_to(:updated)
+      expect(described_class).to respond_to(:info)
+      expect(described_class).to respond_to(:success)
+      expect(described_class).to respond_to(:warning)
+      expect(described_class).to respond_to(:error)
+      expect(described_class).to respond_to(:header)
+      expect(described_class).to respond_to(:dim)
+    end
+  end
+
+  describe "integration scenarios" do
+    context "when stdout is a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(true)
+      end
+
+      it "formats a complete workflow with different message types" do
+        messages = [
+          described_class.header("Creating new application"),
+          described_class.created_directory("my_app"),
+          described_class.created("my_app/config.ru"),
+          described_class.updated("my_app/Gemfile"),
+          described_class.info("Installing dependencies..."),
+          described_class.success("Application created successfully!"),
+          described_class.warning("Remember to run bundle install"),
+          described_class.dim("Additional notes here")
+        ]
+
+        expect(messages).to all(be_a(String))
+        expect(messages.join("\n")).to include("Creating new application")
+        expect(messages.join("\n")).to include("my_app")
+        expect(messages.join("\n")).to include("✓")
+        expect(messages.join("\n")).to include("↻")
+        expect(messages.join("\n")).to include("→")
+        expect(messages.join("\n")).to include("⚠")
+      end
+    end
+
+    context "when stdout is not a tty" do
+      before do
+        allow($stdout).to receive(:tty?).and_return(false)
+      end
+
+      it "formats messages without ANSI codes" do
+        result = described_class.created("test.rb")
+        expect(result).not_to include("\e[")
+        expect(result).to include("✓")
+        expect(result).to include("create")
+        expect(result).to include("test.rb")
+      end
+    end
+  end
+end


### PR DESCRIPTION
👋 Hiya!

> [!CAUTION]
> This PR is draft, I'm looking for feedback on this and only the `hanami new`  command has been tested so far, some output in other commands may not look quite right. Once we determine the approach I'll work on coordinating updating the other commands / testing them.

This is the first stab at an incremental approach to improving the CLI Output to look nice and appealing for users using it.

Following the discussion in https://github.com/hanami/roadmap/issues/11 I wanted to take a try at this and see if I could get my feet involved and put the code to the metal.

## Additions

### Hanami::CLI::Formatter class
Meant to be private internal, but provides us with an interface to take some text and some semantic methods (success, warning, info, heading) and get back ANCI format codes + text. 

## Changes

### Hanami::CLI::Commands::Gem::New
- Updated the new command output to use the Formatter class

### Hanami::CLI::Files class

- New `def created_directory(path)` method for, you guessed it, announcing it created a directory.
- Updated `mkdir(path)` method to use the created_directory method to announce it in the proper formatting.

## Questions

- Does this align with the vision? I normally would probably consider using a method but it seemed apt to make a `Formatter` class and methods that can be used with the existing out.puts code since it's just putting the text and needing color codes.

## Screenshots

<details>
<img width="758" height="1578" alt="CleanShot 2025-09-29 at 18 27 53@2x" src="https://github.com/user-attachments/assets/c8aa546a-1268-4327-9667-20ac6fc7f953" />
</details>


## TODO

- [x] Add specs (can't live with em, can't live without em).
- [x] Test other commands + fix specs