### PR TITLE
Update guides.hanamirb.org links to hanakai.org

### DIFF
--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -55,7 +55,7 @@ module Hanami
             ROM::SQL.migration do
               # Add your migration here.
               #
-              # See https://guides.hanamirb.org/v2.3/database/migrations/ for details.
+              # See https://hanakai.org/learn/hanami/database/migrations/ for details.
               change do
               end
             end

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -74,7 +74,7 @@ module Hanami
               base_path: directory,
               parent_class_name: "#{Hanami.app.namespace}::View::Context",
               auto_register: false,
-              body: ["# Define your view context here. See https://guides.hanamirb.org/views/context/ for details."]
+              body: ["# Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details."]
             ).create(force:)
 
             fs.create(

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -74,7 +74,7 @@ module Hanami
               base_path: directory,
               parent_class_name: "#{Hanami.app.namespace}::View::Context",
               auto_register: false,
-              body: ["# Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details."]
+              body: ["# Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details."] # rubocop:disable Layout/LineLength
             ).create(force:)
 
             fs.create(

--- a/lib/hanami/cli/generators/gem/app/assets.js
+++ b/lib/hanami/cli/generators/gem/app/assets.js
@@ -3,7 +3,7 @@ import * as assets from "hanami-assets";
 // Assets are managed by esbuild (https://esbuild.github.io), and can be
 // customized below.
 //
-// Learn more at https://guides.hanamirb.org/assets/customization/.
+// Learn more at https://hanakai.org/learn/hanami/assets/customization/.
 
 await assets.run({
   esbuildOptionsFn: (args, esbuildOptions) => {

--- a/lib/hanami/cli/generators/gem/app/context.erb
+++ b/lib/hanami/cli/generators/gem/app/context.erb
@@ -4,7 +4,7 @@
 module <%= camelized_app_name %>
   module Views
     class Context < Hanami::View::Context
-      # Define your view context here. See https://guides.hanamirb.org/views/context/ for details.
+      # Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details.
     end
   end
 end

--- a/lib/hanami/cli/generators/gem/app/readme.erb
+++ b/lib/hanami/cli/generators/gem/app/readme.erb
@@ -12,4 +12,4 @@
 ## Useful links
 
 - [Hanami](http://hanamirb.org)
-- [Hanami guides](https://guides.hanamirb.org/)
+- [Hanami guides](https://hanakai.org/learn#hanami)

--- a/lib/hanami/cli/generators/gem/app/routes.erb
+++ b/lib/hanami/cli/generators/gem/app/routes.erb
@@ -2,6 +2,6 @@
 
 module <%= camelized_app_name %>
   class Routes < Hanami::Routes
-    # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
+    # Add your routes here. See https://hanakai.org/learn/hanami/routing/ for details.
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       ROM::SQL.migration do
         # Add your migration here.
         #
-        # See https://guides.hanamirb.org/v2.3/database/migrations/ for details.
+        # See https://hanakai.org/learn/hanami/database/migrations/ for details.
         change do
         end
       end

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
         module Admin
           module Views
             class Context < Test::View::Context
-              # Define your view context here. See https://guides.hanamirb.org/views/context/ for details.
+              # Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details.
             end
           end
         end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         ## Useful links
 
         - [Hanami](http://hanamirb.org)
-        - [Hanami guides](https://guides.hanamirb.org/)
+        - [Hanami guides](https://hanakai.org/learn#hanami)
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
       expect(output).to include("Created README.md")
@@ -307,7 +307,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         // Assets are managed by esbuild (https://esbuild.github.io), and can be
         // customized below.
         //
-        // Learn more at https://guides.hanamirb.org/assets/customization/.
+        // Learn more at https://hanakai.org/learn/hanami/assets/customization/.
 
         await assets.run({
           esbuildOptionsFn: (args, esbuildOptions) => {
@@ -344,7 +344,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         module Bookshelf
           class Routes < Hanami::Routes
-            # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
+            # Add your routes here. See https://hanakai.org/learn/hanami/routing/ for details.
           end
         end
       EXPECTED
@@ -715,7 +715,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           ## Useful links
 
           - [Hanami](http://hanamirb.org)
-          - [Hanami guides](https://guides.hanamirb.org/)
+          - [Hanami guides](https://hanakai.org/learn#hanami)
         EXPECTED
         expect(fs.read("README.md")).to eq(readme)
         expect(output).to include("Created README.md")
@@ -876,7 +876,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           // Assets are managed by esbuild (https://esbuild.github.io), and can be
           // customized below.
           //
-          // Learn more at https://guides.hanamirb.org/assets/customization/.
+          // Learn more at https://hanakai.org/learn/hanami/assets/customization/.
 
           await assets.run({
             esbuildOptionsFn: (args, esbuildOptions) => {
@@ -913,7 +913,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           module Bookshelf
             class Routes < Hanami::Routes
-              # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
+              # Add your routes here. See https://hanakai.org/learn/hanami/routing/ for details.
             end
           end
         EXPECTED
@@ -1035,7 +1035,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           module #{inflector.camelize(app)}
             module Views
               class Context < Hanami::View::Context
-                # Define your view context here. See https://guides.hanamirb.org/views/context/ for details.
+                # Define your view context here. See https://hanakai.org/learn/hanami/views/context/ for details.
               end
             end
           end
@@ -1374,7 +1374,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         ## Useful links
 
         - [Hanami](http://hanamirb.org)
-        - [Hanami guides](https://guides.hanamirb.org/)
+        - [Hanami guides](https://hanakai.org/learn#hanami)
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
 


### PR DESCRIPTION
Most of guide.hanamirb.org links on comments are redirected to [Getting Started - Overview](https://hanakai.org/learn/hanami/v2.3/getting-started) page.

so I'm suggesting updating these to links under hanakai.org/learn.