### PR TITLE
Support SQLite3 JDBC

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -79,7 +79,16 @@ module Hanami
               end
 
               def name
-                database_uri.path.sub(%r{^/}, "")
+                path = database_path
+                # On JRuby we probably converted a relative path to an absolute path, because
+                # the JDBC driver only accepts the latter. Now it's time to convert it back.
+                # This means that JRuby users might sometimes see relative path when they actually
+                # used abosulte path in the configuration.
+                if jruby?
+                  pathname = Pathname.new(path).expand_path
+                  path = pathname.relative_path_from(Dir.current).to_s if pathname.to_s.start_with?("#{Dir.current}/")
+                end
+                path.sub(%r{^/}, "")
               end
 
               def database_url
@@ -196,6 +205,16 @@ module Hanami
               end
 
               private
+
+              def database_path
+                database_uri.path ||
+                  # For `jdbc:` URIs the path is exposed via the opaque component
+                  database_uri.opaque.sub(%r{^\w+:/?}, "")
+              end
+
+              def jruby?
+                RUBY_ENGINE == "jruby"
+              end
 
               def post_process_dump(sql)
                 sql

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -46,6 +46,9 @@ module Hanami
 
               def self.database_class(database_url)
                 database_scheme = URI(database_url).scheme
+                if database_scheme == "jdbc"
+                  database_scheme = URI(database_url.sub("jdbc:", "")).scheme
+                end
                 DATABASE_CLASS_RESOLVER[database_scheme].call
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -67,10 +67,18 @@ module Hanami
               # @api private
               # @since 2.2.0
               def name
-                # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
-                # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
-                # of the path is considered by Ruby's `URI` as the `#host`.
-                @name ||= "#{database_uri.host}#{database_uri.path}"
+                @name ||=
+                  if database_uri.scheme == "jdbc"
+                    # For JDBC SQLite URIs like "jdbc:sqlite:db/app.sqlite3",
+                    # we need to extract the path part after "jdbc:sqlite:"
+                    # The standard URI.parse doesn't handle JDBC URIs well, so we remove the prefix manually
+                    database_url.sub(%r{^jdbc:sqlite:}, "")
+                  else
+                    # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
+                    # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
+                    # of the path is considered by Ruby's `URI` as the `#host`.
+                    "#{database_uri.host}#{database_uri.path}"
+                  end
               end
 
               private

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -67,10 +67,17 @@ module Hanami
               # @api private
               # @since 2.2.0
               def name
-                # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
-                # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
-                # of the path is considered by Ruby's `URI` as the `#host`.
-                @name ||= "#{database_uri.host}#{database_uri.path}"
+                @name ||= if database_uri.scheme == "jdbc"
+                            # For JDBC SQLite URIs like "jdbc:sqlite:db/app.sqlite3",
+                            # we need to extract the path part after "jdbc:sqlite:"
+                            # The standard URI.parse doesn't handle JDBC URIs well, so we remove the prefix manually
+                            database_url.sub(%r{^jdbc:sqlite:}, "")
+                          else
+                            # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
+                            # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
+                            # of the path is considered by Ruby's `URI` as the `#host`.
+                            "#{database_uri.host}#{database_uri.path}"
+                          end
               end
 
               private

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -15,10 +15,6 @@ module RSpec
       def sqlite_url(url, dir: nil)
         url = sqlite_db_name(url, dir:)
         if jruby?
-          # We need to ensure that the parent directory for the database exists, because JDBC driver
-          # won't create it
-          base_dir = File.dirname(url)
-          FileUtils.mkdir_p(base_dir)
           "jdbc:sqlite:#{url}"
         else
           "sqlite://#{url}"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -11,6 +11,29 @@ module RSpec
         expect(actual).to eq(expected)
         actual
       end
+
+      def sqlite_url(url, dir: nil)
+        url = sqlite_db_name(url, dir:)
+        if jruby?
+          # We need to ensure that the parent directory for the database exists, because JDBC driver
+          # won't create it
+          base_dir = File.dirname(url)
+          FileUtils.mkdir_p(base_dir)
+          "jdbc:sqlite:#{url}"
+        else
+          "sqlite://#{url}"
+        end
+      end
+
+      def sqlite_db_name(url, dir: nil)
+        # JDBC driver does not use Dir.current for building the path, so we need to construct
+        # the correct path ourselves
+        jruby? && dir ? File.join(dir, url) : url
+      end
+
+      def jruby?
+        RUBY_ENGINE == "jruby"
+      end
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Support
+    module Helpers
+      def sqlite_url(url, dir: nil)
+        url = sqlite_db_name(url, dir:)
+        if jruby?
+          # We need to ensure that the parent directory for the database exists, because JDBC driver
+          # won't create it
+          base_dir = File.dirname(url)
+          FileUtils.mkdir_p(base_dir)
+          "jdbc:sqlite:#{url}"
+        else
+          "sqlite://#{url}"
+        end
+      end
+
+      def sqlite_db_name(url, dir: nil)
+        # JDBC driver does not use Dir.current for building the path, so we need to construct
+        # the correct path ourselves
+        jruby? && dir ? File.join(dir, url) : url
+      end
+
+      def jruby?
+        RUBY_ENGINE == "jruby"
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpec::Support::Helpers
+end

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       end
 
       it "creates the database" do
@@ -61,16 +61,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
       end
 
       it "does not create the database if it already exists" do
-        FileUtils.mkdir(@dir.join("db"))
+        FileUtils.mkdir_p(@dir.join("db"))
         FileUtils.touch(@dir.join("db", "app.sqlite3"))
 
         command.call
 
-        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
       end
     end
 
@@ -135,8 +135,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-        ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+        ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       end
 
       it "creates each database" do
@@ -148,8 +148,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect { Hanami.app["db.gateway"] }.not_to raise_error
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
-        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
       end
 
       it "creates the app database when given --app" do
@@ -160,8 +160,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
 
       it "creates a slice database when given --slice" do
@@ -172,8 +172,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/main.sqlite3 created"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
 
       it "prints errors for any create commands that fail and exits with non-zero status" do
@@ -190,16 +190,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be false
         expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
 
-        expect(output).to include "failed to create database db/app.sqlite3"
+        expect(output).to include "failed to create database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
         expect(output).to include "app-db-err"
 
-        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
       end
 
       context "app with gateways" do
         def before_prepare
           write "config/db/.keep", ""
-          ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+          ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
         end
 
         it "creates the databases for all the app's gateways when given --app" do
@@ -208,8 +208,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database db/app.sqlite3 created",
-            "database db/app_extra.sqlite3 created"
+            "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
+            "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
           )
         end
 
@@ -218,7 +218,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "app.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database db/app_extra.sqlite3 created"
+          expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
           expect(output).not_to include "database/app.sqlite3"
         end
       end
@@ -226,7 +226,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
       context "slice with gateways" do
         def before_prepare
           write "slices/main/config/db/.keep", ""
-          ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+          ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
         end
 
         it "creates the databases for all the slices's gateways when given --slice" do
@@ -235,8 +235,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database db/main.sqlite3 created",
-            "database db/main_extra.sqlite3 created"
+            "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
+            "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
           )
         end
 
@@ -245,7 +245,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "main.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database db/main_extra.sqlite3 created"
+          expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
           expect(output).not_to include "database/main.sqlite3"
         end
       end
@@ -288,7 +288,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "automatic test env execution" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       end
 
       around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).to include "database db/app.sqlite3 created"
       end
 
       it "does not create the database if it already exists" do
@@ -70,7 +70,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         command.call
 
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).to include "database db/app.sqlite3 created"
       end
     end
 
@@ -148,8 +148,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect { Hanami.app["db.gateway"] }.not_to raise_error
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
-        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
+        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database db/main.sqlite3 created"
       end
 
       it "creates the app database when given --app" do
@@ -160,8 +160,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
-        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).not_to include "db/main.sqlite3"
       end
 
       it "creates a slice database when given --slice" do
@@ -172,8 +172,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
-        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).not_to include "db/app.sqlite3"
       end
 
       it "prints errors for any create commands that fail and exits with non-zero status" do
@@ -190,10 +190,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be false
         expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
 
-        expect(output).to include "failed to create database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
+        expect(output).to include "failed to create database db/app.sqlite3"
         expect(output).to include "app-db-err"
 
-        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
+        expect(output).to include "database db/main.sqlite3 created"
       end
 
       context "app with gateways" do
@@ -208,8 +208,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
-            "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
+            "database db/app.sqlite3 created",
+            "database db/app_extra.sqlite3 created"
           )
         end
 
@@ -218,7 +218,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "app.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
+          expect(output).to include "database db/app_extra.sqlite3 created"
           expect(output).not_to include "database/app.sqlite3"
         end
       end
@@ -235,8 +235,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
-            "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
+            "database db/main.sqlite3 created",
+            "database db/main_extra.sqlite3 created"
           )
         end
 
@@ -245,7 +245,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "main.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
+          expect(output).to include "database db/main_extra.sqlite3 created"
           expect(output).not_to include "database/main.sqlite3"
         end
       end

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       end
 
       it "creates the database" do
@@ -68,16 +68,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
       end
 
       it "does not create the database if it already exists" do
-        FileUtils.mkdir(@dir.join("db"))
+        FileUtils.mkdir_p(@dir.join("db"))
         FileUtils.touch(@dir.join("db", "app.sqlite3"))
 
         command.call
 
-        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
       end
     end
 
@@ -142,8 +142,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-        ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+        ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       end
 
       it "creates each database" do
@@ -155,8 +155,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect { Hanami.app["db.gateway"] }.not_to raise_error
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
-        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
       end
 
       it "creates the app database when given --app" do
@@ -167,8 +167,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/app.sqlite3 created"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
 
       it "creates a slice database when given --slice" do
@@ -179,8 +179,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/main.sqlite3 created"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
 
       it "prints errors for any create commands that fail and exits with non-zero status" do
@@ -197,10 +197,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be false
         expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
 
-        expect(output).to include "failed to create database db/app.sqlite3"
+        expect(output).to include "failed to create database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
         expect(output).to include "app-db-err"
 
-        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created"
 
         expect(command).to have_received(:exit).with(2).once
       end
@@ -208,7 +208,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
       context "app with gateways" do
         def before_prepare
           write "config/db/.keep", ""
-          ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+          ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
         end
 
         it "creates the databases for all the app's gateways when given --app" do
@@ -217,8 +217,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database db/app.sqlite3 created",
-            "database db/app_extra.sqlite3 created"
+            "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
+            "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
           )
         end
 
@@ -227,7 +227,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "app.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database db/app_extra.sqlite3 created"
+          expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} created"
           expect(output).not_to include "database/app.sqlite3"
         end
       end
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
       context "slice with gateways" do
         def before_prepare
           write "slices/main/config/db/.keep", ""
-          ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+          ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
         end
 
         it "creates the databases for all the slices's gateways when given --slice" do
@@ -244,8 +244,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .and change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
 
           expect(output).to include_in_order(
-            "database db/main.sqlite3 created",
-            "database db/main_extra.sqlite3 created"
+            "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
+            "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
           )
         end
 
@@ -254,7 +254,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
             .to change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
             .and not_change { Hanami.app.root.join("db", "main.sqlite3").exist? }.from(false)
 
-          expect(output).to include "database db/main_extra.sqlite3 created"
+          expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} created"
           expect(output).not_to include "database/main.sqlite3"
         end
       end
@@ -299,7 +299,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "automatic test env execution" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       end
 
       around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
         .and change { File.exist?(@dir.join("db", "main.sqlite3")) }
         .to false
 
-      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
-      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database db/app.sqlite3 dropped"
+      expect(output).to include "database db/main.sqlite3 dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be true
 
-      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
-      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+      expect(output).to include "database db/app.sqlite3 dropped"
+      expect(output).not_to include "db/main.sqlite3"
 
       expect(command).not_to have_received(:exit)
     end
@@ -108,8 +108,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
 
-      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
-      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).not_to include "db/app.sqlite3"
 
       expect(command).not_to have_received(:exit)
     end
@@ -120,8 +120,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be false
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
-      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database db/app.sqlite3 dropped"
+      expect(output).to include "database db/main.sqlite3 dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -132,7 +132,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       allow(File).to receive(:unlink).and_call_original
       allow(File).to receive(:unlink)
-        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
+        .with(a_string_including("db/app.sqlite3"))
         .and_raise Errno::EACCES
 
       expect_exit_code(1) { command.call }
@@ -140,10 +140,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "failed to drop database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
+      expect(output).to include "failed to drop database db/app.sqlite3"
       expect(output).to include "Permission denied" # from Errno::EACCESS
 
-      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database db/main.sqlite3 dropped"
     end
 
     context "app and slice with gateways" do
@@ -168,10 +168,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
 
         expect(output.strip).to eq(<<~TEXT.strip)
-          => database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped
-          => database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped
-          => database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped
-          => database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped
+          => database db/app.sqlite3 dropped
+          => database db/app_extra.sqlite3 dropped
+          => database db/main.sqlite3 dropped
+          => database db/main_extra.sqlite3 dropped
         TEXT
 
         expect(command).not_to have_received(:exit)
@@ -195,8 +195,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped",
-          "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
+          "database db/app.sqlite3 dropped",
+          "database db/app_extra.sqlite3 dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -207,7 +207,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "app.sqlite3")) }.from(true)
 
-        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
+        expect(output).to include "database db/app_extra.sqlite3 dropped"
         expect(output).not_to include "database/app.sqlite3"
       end
     end
@@ -229,8 +229,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped",
-          "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
+          "database db/main.sqlite3 dropped",
+          "database db/main_extra.sqlite3 dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -241,7 +241,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "main.sqlite3")) }.from(true)
 
-        expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
+        expect(output).to include "database db/main_extra.sqlite3 dropped"
         expect(output).not_to include "database/main.sqlite3"
 
         expect(command).not_to have_received(:exit)

--- a/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
     end
 
     it "drops each database" do
@@ -72,8 +72,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
         .and change { File.exist?(@dir.join("db", "main.sqlite3")) }
         .to false
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be true
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).not_to include "db/main.sqlite3"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
 
       expect(command).not_to have_received(:exit)
     end
@@ -108,8 +108,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
 
-      expect(output).to include "database db/main.sqlite3 dropped"
-      expect(output).not_to include "db/app.sqlite3"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
+      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
 
       expect(command).not_to have_received(:exit)
     end
@@ -120,8 +120,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be false
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -132,7 +132,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       allow(File).to receive(:unlink).and_call_original
       allow(File).to receive(:unlink)
-        .with(a_string_including("db/app.sqlite3"))
+        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
         .and_raise Errno::EACCES
 
       expect_exit_code(1) { command.call }
@@ -140,10 +140,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "failed to drop database db/app.sqlite3"
+      expect(output).to include "failed to drop database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
       expect(output).to include "Permission denied" # from Errno::EACCESS
 
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
     end
 
     context "app and slice with gateways" do
@@ -151,8 +151,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
         write "config/db/.keep", ""
         write "slices/main/config/db/.keep", ""
 
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -168,10 +168,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
 
         expect(output.strip).to eq(<<~TEXT.strip)
-          => database db/app.sqlite3 dropped
-          => database db/app_extra.sqlite3 dropped
-          => database db/main.sqlite3 dropped
-          => database db/main_extra.sqlite3 dropped
+          => database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped
         TEXT
 
         expect(command).not_to have_received(:exit)
@@ -181,7 +181,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
     context "app with gateways" do
       def before_prepare
         write "config/db/.keep", ""
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -195,8 +195,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database db/app.sqlite3 dropped",
-          "database db/app_extra.sqlite3 dropped"
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped",
+          "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -207,7 +207,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "app.sqlite3")) }.from(true)
 
-        expect(output).to include "database db/app_extra.sqlite3 dropped"
+        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
         expect(output).not_to include "database/app.sqlite3"
       end
     end
@@ -215,7 +215,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
     context "slice with gateways" do
       def before_prepare
         write "slices/main/config/db/.keep", ""
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -229,8 +229,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database db/main.sqlite3 dropped",
-          "database db/main_extra.sqlite3 dropped"
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped",
+          "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -241,7 +241,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "main.sqlite3")) }.from(true)
 
-        expect(output).to include "database db/main_extra.sqlite3 dropped"
+        expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
         expect(output).not_to include "database/main.sqlite3"
 
         expect(command).not_to have_received(:exit)
@@ -442,7 +442,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
     end
 
     it "drops each database" do
@@ -72,8 +72,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
         .and change { File.exist?(@dir.join("db", "main.sqlite3")) }
         .to false
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be true
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).not_to include "db/main.sqlite3"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
 
       expect(command).not_to have_received(:exit)
     end
@@ -108,8 +108,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
 
-      expect(output).to include "database db/main.sqlite3 dropped"
-      expect(output).not_to include "db/app.sqlite3"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
+      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
 
       expect(command).not_to have_received(:exit)
     end
@@ -120,8 +120,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be false
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "database db/app.sqlite3 dropped"
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
 
       expect(command).not_to have_received(:exit)
     end
@@ -132,7 +132,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
       allow(File).to receive(:unlink).and_call_original
       allow(File).to receive(:unlink)
-        .with(a_string_including("db/app.sqlite3"))
+        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
         .and_raise Errno::EACCES
 
       command.call
@@ -140,10 +140,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
       expect(File.exist?(@dir.join("db", "app.sqlite3"))).to be true
       expect(File.exist?(@dir.join("db", "main.sqlite3"))).to be false
 
-      expect(output).to include "failed to drop database db/app.sqlite3"
+      expect(output).to include "failed to drop database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
       expect(output).to include "Permission denied" # from Errno::EACCESS
 
-      expect(output).to include "database db/main.sqlite3 dropped"
+      expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped"
 
       expect(command).to have_received(:exit).with(1).once
     end
@@ -153,8 +153,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
         write "config/db/.keep", ""
         write "slices/main/config/db/.keep", ""
 
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -170,10 +170,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
 
         expect(output.strip).to eq(<<~TEXT.strip)
-          => database db/app.sqlite3 dropped
-          => database db/app_extra.sqlite3 dropped
-          => database db/main.sqlite3 dropped
-          => database db/main_extra.sqlite3 dropped
+          => database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped
+          => database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped
         TEXT
 
         expect(command).not_to have_received(:exit)
@@ -183,7 +183,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
     context "app with gateways" do
       def before_prepare
         write "config/db/.keep", ""
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -197,8 +197,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database db/app.sqlite3 dropped",
-          "database db/app_extra.sqlite3 dropped"
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} dropped",
+          "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -209,7 +209,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "app_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "app.sqlite3")) }.from(true)
 
-        expect(output).to include "database db/app_extra.sqlite3 dropped"
+        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} dropped"
         expect(output).not_to include "database/app.sqlite3"
       end
     end
@@ -217,7 +217,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
     context "slice with gateways" do
       def before_prepare
         write "slices/main/config/db/.keep", ""
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
       end
 
       before do
@@ -231,8 +231,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .and change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to false
 
         expect(output).to include_in_order(
-          "database db/main.sqlite3 dropped",
-          "database db/main_extra.sqlite3 dropped"
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} dropped",
+          "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
         )
 
         expect(command).not_to have_received(:exit)
@@ -243,7 +243,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
           .to change { File.exist?(@dir.join("db", "main_extra.sqlite3")) }.to(false)
           .and not_change { File.exist?(@dir.join("db", "main.sqlite3")) }.from(true)
 
-        expect(output).to include "database db/main_extra.sqlite3 dropped"
+        expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} dropped"
         expect(output).not_to include "database/main.sqlite3"
 
         expect(command).not_to have_received(:exit)
@@ -448,7 +448,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app_integration do
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).once
 
         expect(output).to include_in_order(
-          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated",
-          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated"
+          "database db/app.sqlite3 migrated",
+          "database db/main.sqlite3 migrated"
         )
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         expect(dump_command).to have_received(:call).once
 
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated"
+        expect(output).to include "database db/app.sqlite3 migrated"
         expect(output).not_to include "main.sqlite3"
       end
 
@@ -127,7 +127,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         expect(dump_command).to have_received(:call).exactly(1).time
 
-        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated"
+        expect(output).to include "database db/main.sqlite3 migrated"
         expect(output).not_to include "app.sqlite3"
       end
 
@@ -177,8 +177,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).once
 
           expect(output).to include_in_order(
-            "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated in",
-            "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} migrated in"
+            "database db/app.sqlite3 migrated in",
+            "database db/app_extra.sqlite3 migrated in"
           )
         end
 
@@ -191,8 +191,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil, gateway: "extra"))
           expect(dump_command).to have_received(:call).once
 
-          expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} migrated in"
-          expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+          expect(output).to include "database db/app_extra.sqlite3 migrated in"
+          expect(output).not_to include "db/app.sqlite3"
         end
       end
 
@@ -224,8 +224,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).once
 
           expect(output).to include_in_order(
-            "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated in",
-            "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} migrated in"
+            "database db/main.sqlite3 migrated in",
+            "database db/main_extra.sqlite3 migrated in"
           )
         end
 
@@ -238,8 +238,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).with(hash_including(slice: "main", gateway: "extra"))
           expect(dump_command).to have_received(:call).once
 
-          expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} migrated in"
-          expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+          expect(output).to include "database db/main_extra.sqlite3 migrated in"
+          expect(output).not_to include "db/main.sqlite3"
         end
       end
     end
@@ -338,7 +338,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     it "migrates the database using the slice with config/db/" do
       command.call
 
-      expect(output).to include "database #{sqlite_db_name("db/shared.sqlite3", dir: @dir)} migrated"
+      expect(output).to include "database db/shared.sqlite3 migrated"
       expect(output).not_to include "WARNING"
 
       expect(Admin::Slice["db.gateway"].connection.tables).to include :posts
@@ -383,11 +383,11 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include_in_order(
-        "WARNING: Database #{sqlite_db_name("db/confused.sqlite3", dir: @dir)} is configured for multiple config/db/ directories",
+        "WARNING: Database db/confused.sqlite3 is configured for multiple config/db/ directories",
         "- slices/admin/config/db",
         "- slices/main/config/db",
         'Using config in "admin" slice only',
-        "database #{sqlite_db_name("db/confused.sqlite3", dir: @dir)} migrated"
+        "database db/confused.sqlite3 migrated"
       )
 
       expect(Admin::Slice["db.gateway"].connection.tables).to include :posts
@@ -408,7 +408,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include(
-        "WARNING: Database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} expects the folder config/db/ to exist but it does not."
+        "WARNING: Database db/app.sqlite3 expects the folder config/db/ to exist but it does not."
       )
       expect(output).not_to include "migrated"
     end
@@ -453,8 +453,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     it "migrates the database using the slice with config/db/" do
       command.call
 
-      expect(output).to include "database #{sqlite_db_name("db/comments.sqlite3", dir: @dir)} migrated"
-      expect(output).to include "database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} migrated"
+      expect(output).to include "database db/comments.sqlite3 migrated"
+      expect(output).to include "database db/posts.sqlite3 migrated"
       expect(output).not_to include "WARNING"
 
       expect(Admin::Slice["db.gateways.posts"].connection.tables).to include :posts
@@ -514,12 +514,12 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include_in_order(
-        "WARNING: Database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} is configured for multiple config/db/ directories:",
+        "WARNING: Database db/posts.sqlite3 is configured for multiple config/db/ directories:",
         "- slices/admin/config/db",
         "- slices/main/config/db",
         %(Using config in "admin" slice only.),
-        "database #{sqlite_db_name("db/comments.sqlite3", dir: @dir)} migrated",
-        "database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} migrated"
+        "database db/comments.sqlite3 migrated",
+        "database db/posts.sqlite3 migrated"
       )
 
       expect(Admin::Slice["db.gateways.posts"].connection.tables).to include :posts
@@ -541,7 +541,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include(
-        "WARNING: Database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} expects migrations to be located within config/db/migrate/ but that folder does not exist."
+        "WARNING: Database db/app.sqlite3 expects migrations to be located within config/db/migrate/ but that folder does not exist."
       )
       expect(output).to include("No database migrations can be run for this database.")
       expect(output).not_to include "migrated"
@@ -564,7 +564,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include(
-        "NOTE: Empty database migrations folder (config/db/migrate/) for #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
+        "NOTE: Empty database migrations folder (config/db/migrate/) for db/app.sqlite3"
       )
       expect(output).not_to include "migrated"
     end

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-        ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+        ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+        ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
         db_create
       end
 
@@ -100,8 +100,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).once
 
         expect(output).to include_in_order(
-          "database db/app.sqlite3 migrated",
-          "database db/main.sqlite3 migrated"
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated",
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated"
         )
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         expect(dump_command).to have_received(:call).once
 
-        expect(output).to include "database db/app.sqlite3 migrated"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated"
         expect(output).not_to include "main.sqlite3"
       end
 
@@ -127,7 +127,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         expect(dump_command).to have_received(:call).exactly(1).time
 
-        expect(output).to include "database db/main.sqlite3 migrated"
+        expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated"
         expect(output).not_to include "app.sqlite3"
       end
 
@@ -153,7 +153,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         def before_prepare
           super
 
-          ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+          ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
 
           write "config/db/extra_migrate/20240602201330_create_comments.rb", <<~RUBY
             ROM::SQL.migration do
@@ -177,8 +177,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).once
 
           expect(output).to include_in_order(
-            "database db/app.sqlite3 migrated in",
-            "database db/app_extra.sqlite3 migrated in"
+            "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated in",
+            "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} migrated in"
           )
         end
 
@@ -191,8 +191,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil, gateway: "extra"))
           expect(dump_command).to have_received(:call).once
 
-          expect(output).to include "database db/app_extra.sqlite3 migrated in"
-          expect(output).not_to include "db/app.sqlite3"
+          expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} migrated in"
+          expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
         end
       end
 
@@ -200,7 +200,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
         def before_prepare
           super
 
-          ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+          ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
 
           write "slices/main/config/db/extra_migrate/20240602201330_create_comments.rb", <<~RUBY
             ROM::SQL.migration do
@@ -224,8 +224,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).once
 
           expect(output).to include_in_order(
-            "database db/main.sqlite3 migrated in",
-            "database db/main_extra.sqlite3 migrated in"
+            "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated in",
+            "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} migrated in"
           )
         end
 
@@ -238,8 +238,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           expect(dump_command).to have_received(:call).with(hash_including(slice: "main", gateway: "extra"))
           expect(dump_command).to have_received(:call).once
 
-          expect(output).to include "database db/main_extra.sqlite3 migrated in"
-          expect(output).not_to include "db/main.sqlite3"
+          expect(output).to include "database #{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} migrated in"
+          expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
         end
       end
     end
@@ -330,15 +330,15 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["ADMIN__DATABASE_URL"] = "sqlite://db/shared.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/shared.sqlite3"
+      ENV["ADMIN__DATABASE_URL"] = sqlite_url("db/shared.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/shared.sqlite3", dir: @dir)
       db_create
     end
 
     it "migrates the database using the slice with config/db/" do
       command.call
 
-      expect(output).to include "database db/shared.sqlite3 migrated"
+      expect(output).to include "database #{sqlite_db_name("db/shared.sqlite3", dir: @dir)} migrated"
       expect(output).not_to include "WARNING"
 
       expect(Admin::Slice["db.gateway"].connection.tables).to include :posts
@@ -374,8 +374,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["ADMIN__DATABASE_URL"] = "sqlite://db/confused.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/confused.sqlite3"
+      ENV["ADMIN__DATABASE_URL"] = sqlite_url("db/confused.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/confused.sqlite3", dir: @dir)
       db_create
     end
 
@@ -383,11 +383,11 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include_in_order(
-        "WARNING: Database db/confused.sqlite3 is configured for multiple config/db/ directories",
+        "WARNING: Database #{sqlite_db_name("db/confused.sqlite3", dir: @dir)} is configured for multiple config/db/ directories",
         "- slices/admin/config/db",
         "- slices/main/config/db",
         'Using config in "admin" slice only',
-        "database db/confused.sqlite3 migrated"
+        "database #{sqlite_db_name("db/confused.sqlite3", dir: @dir)} migrated"
       )
 
       expect(Admin::Slice["db.gateway"].connection.tables).to include :posts
@@ -401,14 +401,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     it "prints a warning, and does not migrate the database" do
       command.call
 
       expect(output).to include(
-        "WARNING: Database db/app.sqlite3 expects the folder config/db/ to exist but it does not."
+        "WARNING: Database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} expects the folder config/db/ to exist but it does not."
       )
       expect(output).not_to include "migrated"
     end
@@ -443,18 +443,18 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["ADMIN__DATABASE_URL__POSTS"] = "sqlite://db/posts.sqlite3"
-      ENV["ADMIN__DATABASE_URL__COMMENTS"] = "sqlite://db/comments.sqlite3"
-      ENV["MAIN__DATABASE_URL__POSTS"] = "sqlite://db/posts.sqlite3"
-      ENV["MAIN__DATABASE_URL__COMMENTS"] = "sqlite://db/comments.sqlite3"
+      ENV["ADMIN__DATABASE_URL__POSTS"] = sqlite_url("db/posts.sqlite3", dir: @dir)
+      ENV["ADMIN__DATABASE_URL__COMMENTS"] = sqlite_url("db/comments.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL__POSTS"] = sqlite_url("db/posts.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL__COMMENTS"] = sqlite_url("db/comments.sqlite3", dir: @dir)
       db_create
     end
 
     it "migrates the database using the slice with config/db/" do
       command.call
 
-      expect(output).to include "database db/comments.sqlite3 migrated"
-      expect(output).to include "database db/posts.sqlite3 migrated"
+      expect(output).to include "database #{sqlite_db_name("db/comments.sqlite3", dir: @dir)} migrated"
+      expect(output).to include "database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} migrated"
       expect(output).not_to include "WARNING"
 
       expect(Admin::Slice["db.gateways.posts"].connection.tables).to include :posts
@@ -503,10 +503,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["ADMIN__DATABASE_URL__POSTS"] = "sqlite://db/posts.sqlite3"
-      ENV["ADMIN__DATABASE_URL__COMMENTS"] = "sqlite://db/comments.sqlite3"
-      ENV["MAIN__DATABASE_URL__POSTS"] = "sqlite://db/posts.sqlite3"
-      ENV["MAIN__DATABASE_URL__COMMENTS"] = "sqlite://db/comments.sqlite3"
+      ENV["ADMIN__DATABASE_URL__POSTS"] = sqlite_url("db/posts.sqlite3", dir: @dir)
+      ENV["ADMIN__DATABASE_URL__COMMENTS"] = sqlite_url("db/comments.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL__POSTS"] = sqlite_url("db/posts.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL__COMMENTS"] = sqlite_url("db/comments.sqlite3", dir: @dir)
       db_create
     end
 
@@ -514,12 +514,12 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include_in_order(
-        "WARNING: Database db/posts.sqlite3 is configured for multiple config/db/ directories:",
+        "WARNING: Database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} is configured for multiple config/db/ directories:",
         "- slices/admin/config/db",
         "- slices/main/config/db",
         %(Using config in "admin" slice only.),
-        "database db/comments.sqlite3 migrated",
-        "database db/posts.sqlite3 migrated"
+        "database #{sqlite_db_name("db/comments.sqlite3", dir: @dir)} migrated",
+        "database #{sqlite_db_name("db/posts.sqlite3", dir: @dir)} migrated"
       )
 
       expect(Admin::Slice["db.gateways.posts"].connection.tables).to include :posts
@@ -534,14 +534,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     it "prints a warning, and does not migrate the database" do
       command.call
 
       expect(output).to include(
-        "WARNING: Database db/app.sqlite3 expects migrations to be located within config/db/migrate/ but that folder does not exist."
+        "WARNING: Database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} expects migrations to be located within config/db/migrate/ but that folder does not exist."
       )
       expect(output).to include("No database migrations can be run for this database.")
       expect(output).not_to include "migrated"
@@ -556,7 +556,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
 
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       db_create
     end
 
@@ -564,7 +564,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include(
-        "NOTE: Empty database migrations folder (config/db/migrate/) for db/app.sqlite3"
+        "NOTE: Empty database migrations folder (config/db/migrate/) for #{sqlite_db_name("db/app.sqlite3", dir: @dir)}"
       )
       expect(output).not_to include "migrated"
     end
@@ -572,7 +572,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
       db_create
     end
 

--- a/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
@@ -174,14 +174,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
         SQL
 
         expect(output).to include_in_order(
-          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
-          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
-          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
-          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql",
-          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated",
-          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
-          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated",
-          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql",
+          "database db/app.sqlite3 created",
+          "db/app.sqlite3 structure loaded from config/db/structure.sql",
+          "database db/main.sqlite3 created",
+          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql",
+          "database db/app.sqlite3 migrated",
+          "db/app.sqlite3 structure dumped to config/db/structure.sql",
+          "database db/main.sqlite3 migrated",
+          "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql",
           "seed data loaded from config/db/seeds.rb",
           "seed data loaded from slices/main/config/db/seeds.rb"
         )

--- a/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
     end
 
     context "from scratch, with structure dump and seeds" do
@@ -174,14 +174,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
         SQL
 
         expect(output).to include_in_order(
-          "database db/app.sqlite3 created",
-          "db/app.sqlite3 structure loaded from config/db/structure.sql",
-          "database db/main.sqlite3 created",
-          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql",
-          "database db/app.sqlite3 migrated",
-          "db/app.sqlite3 structure dumped to config/db/structure.sql",
-          "database db/main.sqlite3 migrated",
-          "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql",
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql",
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated",
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated",
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql",
           "seed data loaded from config/db/seeds.rb",
           "seed data loaded from slices/main/config/db/seeds.rb"
         )
@@ -437,7 +437,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/prepare_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
     end
 
     context "from scratch, with structure dump and seeds" do
@@ -174,14 +174,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
         SQL
 
         expect(output).to include_in_order(
-          "database db/app.sqlite3 created",
-          "db/app.sqlite3 structure loaded from config/db/structure.sql",
-          "database db/main.sqlite3 created",
-          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql",
-          "database db/app.sqlite3 migrated",
-          "db/app.sqlite3 structure dumped to config/db/structure.sql",
-          "database db/main.sqlite3 migrated",
-          "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql",
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} created",
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} created",
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql",
+          "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} migrated",
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
+          "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} migrated",
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql",
           "seed data loaded from config/db/seeds.rb",
           "seed data loaded from slices/main/config/db/seeds.rb"
         )
@@ -439,7 +439,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Prepare, :app_integration do
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
@@ -82,14 +82,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
   # there's no real reason to repeat all edge cases against all databases. This would be slow down
   # tests and add unnecessary clutter to this test file.
   describe "sqlite" do
-    before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
-    end
-
     context "with one database" do
       it "rolls back the most recent migration found" do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -114,7 +110,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         command.call
 
         expect(columns.()).to eq [:id, :title, :body]
-        expect(output).to include "database db/app.sqlite3 rolled back to 20250603211330_add_body_to_posts in"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250603211330_add_body_to_posts in"
         expect(dump_command).to have_received(:call).with(hash_including(app: true)).once
       end
     end
@@ -122,6 +118,9 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
     context "with multiple databases" do
       before do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+          ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -163,7 +162,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         it "defaults to app database when only one database context exists" do
           command.call
 
-          expect(output).to include("database db/app.sqlite3 rolled back")
+          expect(output).to include("database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back")
         end
       end
 
@@ -175,7 +174,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "2", slice: "main")
 
           expect(Main::Slice["db.gateway"].connection.tables).not_to include :invoices
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -186,8 +185,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(app: true)
 
           expect(columns.()).to eq [:id, :title, :body]
-          expect(output).to include "database db/app.sqlite3 rolled back"
-          expect(output).to_not include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
+          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -198,8 +197,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "3", app: true)
 
           expect(Hanami.app["db.gateway"].connection.tables).not_to include :posts
-          expect(output).to include "database db/app.sqlite3 rolled back"
-          expect(output).to_not include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
+          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -210,7 +209,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(slice: "main")
 
           expect(columns.()).to eq [:id, :amount]
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -236,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call(target: "20250602201330")
 
-          expect(output).to include "database db/app.sqlite3 rolled back to 20250602201330_create_posts"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250602201330_create_posts"
         end
 
         it "rollback everything on selected database when steps flag is bigger than the number of migrations" do
@@ -244,7 +243,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call
 
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).exactly(2).times
         end
 
@@ -258,11 +257,11 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
     context "app with multiple gateways" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
-        ENV["DATABASE_URL__SUPER"] = "sqlite://db/app_super.sqlite3"
-
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+          ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
+          ENV["DATABASE_URL__SUPER"] = sqlite_url("db/app_super.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -302,18 +301,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil, gateway: "extra"))
         expect(dump_command).to have_received(:call).once
 
-        expect(output).to include "database db/app_extra.sqlite3 rolled back"
-        expect(output).not_to include "db/app.sqlite3"
-        expect(output).not_to include "db/app_super.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} rolled back"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+        expect(output).not_to include sqlite_db_name("db/app_super.sqlite3", dir: @dir)
       end
     end
 
     describe "automatic test env execution" do
       let(:test_env_executor) { instance_spy(Hanami::CLI::InteractiveSystemCall) }
-
-      before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      end
 
       around do |example|
         as_hanami_cli_with_args(%w[db rollback]) { example.run }
@@ -321,6 +316,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
       it "re-executes the command in test env when run in development env" do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App

--- a/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         command.call
 
         expect(columns.()).to eq [:id, :title, :body]
-        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250603211330_add_body_to_posts in"
+        expect(output).to include "database db/app.sqlite3 rolled back to 20250603211330_add_body_to_posts in"
         expect(dump_command).to have_received(:call).with(hash_including(app: true)).once
       end
     end
@@ -162,7 +162,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         it "defaults to app database when only one database context exists" do
           command.call
 
-          expect(output).to include("database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back")
+          expect(output).to include("database db/app.sqlite3 rolled back")
         end
       end
 
@@ -174,7 +174,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "2", slice: "main")
 
           expect(Main::Slice["db.gateway"].connection.tables).not_to include :invoices
-          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
+          expect(output).to include "database db/main.sqlite3 rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -185,8 +185,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(app: true)
 
           expect(columns.()).to eq [:id, :title, :body]
-          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
-          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
+          expect(output).to include "database db/app.sqlite3 rolled back"
+          expect(output).to_not include "database db/main.sqlite3 rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -197,8 +197,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "3", app: true)
 
           expect(Hanami.app["db.gateway"].connection.tables).not_to include :posts
-          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
-          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
+          expect(output).to include "database db/app.sqlite3 rolled back"
+          expect(output).to_not include "database db/main.sqlite3 rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -209,7 +209,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(slice: "main")
 
           expect(columns.()).to eq [:id, :amount]
-          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
+          expect(output).to include "database db/main.sqlite3 rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -235,7 +235,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call(target: "20250602201330")
 
-          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250602201330_create_posts"
+          expect(output).to include "database db/app.sqlite3 rolled back to 20250602201330_create_posts"
         end
 
         it "rollback everything on selected database when steps flag is bigger than the number of migrations" do
@@ -243,7 +243,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call
 
-          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
+          expect(output).to include "database db/main.sqlite3 rolled back"
           expect(dump_command).to have_received(:call).exactly(2).times
         end
 
@@ -301,9 +301,9 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil, gateway: "extra"))
         expect(dump_command).to have_received(:call).once
 
-        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} rolled back"
-        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
-        expect(output).not_to include sqlite_db_name("db/app_super.sqlite3", dir: @dir)
+        expect(output).to include "database db/app_extra.sqlite3 rolled back"
+        expect(output).not_to include "db/app.sqlite3"
+        expect(output).not_to include "db/app_super.sqlite3"
       end
     end
 

--- a/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
@@ -92,14 +92,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
   # there's no real reason to repeat all edge cases against all databases. This would be slow down
   # tests and add unnecessary clutter to this test file.
   describe "sqlite" do
-    before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
-    end
-
     context "with one database" do
       it "rolls back the most recent migration found" do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -124,7 +120,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         command.call
 
         expect(columns.()).to eq [:id, :title, :body]
-        expect(output).to include "database db/app.sqlite3 rolled back to 20250603211330_add_body_to_posts in"
+        expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250603211330_add_body_to_posts in"
         expect(dump_command).to have_received(:call).with(hash_including(app: true)).once
       end
     end
@@ -132,6 +128,9 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
     context "with multiple databases" do
       before do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+          ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -177,7 +176,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         it "defaults to app database when only one database context exists" do
           command.call
 
-          expect(output).to include("database db/app.sqlite3 rolled back")
+          expect(output).to include("database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back")
         end
       end
 
@@ -189,7 +188,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "2", slice: "main")
 
           expect(Main::Slice["db.gateway"].connection.tables).not_to include :invoices
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -200,8 +199,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(app: true)
 
           expect(columns.()).to eq [:id, :title, :body]
-          expect(output).to include "database db/app.sqlite3 rolled back"
-          expect(output).to_not include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
+          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -212,8 +211,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(steps: "3", app: true)
 
           expect(Hanami.app["db.gateway"].connection.tables).not_to include :posts
-          expect(output).to include "database db/app.sqlite3 rolled back"
-          expect(output).to_not include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back"
+          expect(output).to_not include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil))
         end
 
@@ -224,7 +223,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
           command.call(slice: "main")
 
           expect(columns.()).to eq [:id, :amount]
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).with(hash_including(app: false, slice: "main"))
         end
 
@@ -250,7 +249,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call(target: "20250602201330")
 
-          expect(output).to include "database db/app.sqlite3 rolled back to 20250602201330_create_posts"
+          expect(output).to include "database #{sqlite_db_name("db/app.sqlite3", dir: @dir)} rolled back to 20250602201330_create_posts"
         end
 
         it "rollback everything on selected database when steps flag is bigger than the number of migrations" do
@@ -258,7 +257,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
           command.call
 
-          expect(output).to include "database db/main.sqlite3 rolled back"
+          expect(output).to include "database #{sqlite_db_name("db/main.sqlite3", dir: @dir)} rolled back"
           expect(dump_command).to have_received(:call).exactly(2).times
         end
 
@@ -272,11 +271,11 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
     context "app with multiple gateways" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
-        ENV["DATABASE_URL__SUPER"] = "sqlite://db/app_super.sqlite3"
-
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+          ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
+          ENV["DATABASE_URL__SUPER"] = sqlite_url("db/app_super.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App
@@ -318,18 +317,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
         expect(dump_command).to have_received(:call).with(hash_including(app: true, slice: nil, gateway: "extra"))
         expect(dump_command).to have_received(:call).once
 
-        expect(output).to include "database db/app_extra.sqlite3 rolled back"
-        expect(output).not_to include "db/app.sqlite3"
-        expect(output).not_to include "db/app_super.sqlite3"
+        expect(output).to include "database #{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} rolled back"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+        expect(output).not_to include sqlite_db_name("db/app_super.sqlite3", dir: @dir)
       end
     end
 
     describe "automatic test env execution" do
       let(:test_env_executor) { instance_spy(Hanami::CLI::InteractiveSystemCall) }
-
-      before do
-        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      end
 
       around do |example|
         as_hanami_cli_with_args(%w[db rollback]) { example.run }
@@ -337,6 +332,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app_integration do
 
       it "re-executes the command in test env when run in development env" do
         with_directory(@dir = make_tmp_directory) do
+          ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+
           write "config/app.rb", <<~RUBY
             module TestApp
               class App < Hanami::App

--- a/spec/unit/hanami/cli/commands/app/db/seed_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/seed_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Seed, :app_integration do
   end
 
   before do
-    ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-    ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+    ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+    ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
 
     db_migrate
   end

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       SQL
 
       expect(output).to include_in_order(
-        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
-        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+        "db/app.sqlite3 structure dumped to config/db/structure.sql",
+        "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
       )
     end
 
@@ -109,8 +109,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
-      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+      expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
+      expect(output).not_to include "db/main.sqlite3"
     end
 
     it "dumps the structure for a slice db when given --slice" do
@@ -119,8 +119,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
-      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+      expect(output).not_to include "db/app.sqlite3"
     end
 
     context "app with gateways" do
@@ -145,8 +145,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
-        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
+        expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
+        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --app and --gateway" do
@@ -155,8 +155,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
-        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
+        expect(output).not_to include "db/app.sqlite3"
       end
     end
 
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
-        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --slice and --gateway" do
@@ -192,8 +192,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
-        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).not_to include "db/main.sqlite3"
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       allow(system_call).to receive(:call).and_call_original
       allow(system_call)
         .to receive(:call)
-        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
+        .with(a_string_including("db/app.sqlite3"))
         .and_return Hanami::CLI::SystemCall::Result.new(exit_code: 2, out: "", err: "dump-err")
 
       expect_exit_code(2) { command.call }
@@ -210,8 +210,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include %("#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql" FAILED)
-      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+      expect(output).to include %("db/app.sqlite3 structure dumped to config/db/structure.sql" FAILED)
+      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       db_migrate
     end
 
@@ -98,8 +98,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       SQL
 
       expect(output).to include_in_order(
-        "db/app.sqlite3 structure dumped to config/db/structure.sql",
-        "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
+        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
       )
     end
 
@@ -109,8 +109,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
-      expect(output).not_to include "db/main.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
+      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
     end
 
     it "dumps the structure for a slice db when given --slice" do
@@ -119,13 +119,13 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
-      expect(output).not_to include "db/app.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
     end
 
     context "app with gateways" do
       def before_prepare
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
 
         write "config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -145,8 +145,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
-        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --app and --gateway" do
@@ -155,14 +155,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
     end
 
     context "slice with gateways" do
       def before_prepare
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
 
         write "slices/main/config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
-        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --slice and --gateway" do
@@ -192,8 +192,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       allow(system_call).to receive(:call).and_call_original
       allow(system_call)
         .to receive(:call)
-        .with(a_string_including("db/app.sqlite3"))
+        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
         .and_return Hanami::CLI::SystemCall::Result.new(exit_code: 2, out: "", err: "dump-err")
 
       expect_exit_code(2) { command.call }
@@ -210,8 +210,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include %("db/app.sqlite3 structure dumped to config/db/structure.sql" FAILED)
-      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+      expect(output).to include %("#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql" FAILED)
+      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       db_migrate
     end
 
@@ -98,8 +98,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       SQL
 
       expect(output).to include_in_order(
-        "db/app.sqlite3 structure dumped to config/db/structure.sql",
-        "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql",
+        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
       )
     end
 
@@ -109,8 +109,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
-      expect(output).not_to include "db/main.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
+      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
     end
 
     it "dumps the structure for a slice db when given --slice" do
@@ -119,13 +119,13 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
-      expect(output).not_to include "db/app.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
     end
 
     context "app with gateways" do
       def before_prepare
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
 
         write "config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -145,8 +145,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "db/app.sqlite3 structure dumped to config/db/structure.sql"
-        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --app and --gateway" do
@@ -155,14 +155,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Hanami.app.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "db/app_extra.sqlite3 structure dumped to config/db/extra_structure.sql"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure dumped to config/db/extra_structure.sql"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
     end
 
     context "slice with gateways" do
       def before_prepare
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
 
         write "slices/main/config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
 
-        expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
-        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
       end
 
       it "dumps the structure for for a slice's gateway when given --slice and --gateway" do
@@ -192,8 +192,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
         expect(Main::Slice.root.join("config", "db", "extra_structure.sql").exist?).to be true
         expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be false
 
-        expect(output).to include "db/main_extra.sqlite3 structure dumped to slices/main/config/db/extra_structure.sql"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/extra_structure.sql"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       allow(system_call).to receive(:call).and_call_original
       allow(system_call)
         .to receive(:call)
-        .with(a_string_including("db/app.sqlite3"))
+        .with(a_string_including(sqlite_db_name("db/app.sqlite3", dir: @dir)))
         .and_return Hanami::CLI::SystemCall::Result.new(exit_code: 2, out: "", err: "dump-err")
 
       command.call
@@ -210,8 +210,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       expect(Main::Slice.root.join("config", "db", "structure.sql").exist?).to be true
       expect(Hanami.app.root.join("config", "db", "structure.sql").exist?).to be false
 
-      expect(output).to include %("db/app.sqlite3 structure dumped to config/db/structure.sql" FAILED)
-      expect(output).to include "db/main.sqlite3 structure dumped to slices/main/config/db/structure.sql"
+      expect(output).to include %("#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure dumped to config/db/structure.sql" FAILED)
+      expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure dumped to slices/main/config/db/structure.sql"
 
       expect(command).to have_received(:exit).with 2
     end

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
         .to true
 
       expect(output).to include_in_order(
-        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
-        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql"
+        "db/app.sqlite3 structure loaded from config/db/structure.sql",
+        "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql"
       )
     end
 
@@ -130,8 +130,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql in",
-          "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
+          "db/app.sqlite3 structure loaded from config/db/structure.sql in",
+          "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
         )
       end
 
@@ -142,8 +142,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Hanami.app["db.gateways.default"].connection.tables.include?(:posts) }
           .from false
 
-        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
-        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+        expect(output).to include "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
+        expect(output).not_to include "db/app.sqlite3"
       end
     end
 
@@ -170,8 +170,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql in",
-          "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
+          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql in",
+          "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
         )
       end
 
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Main::Slice["db.gateways.default"].connection.tables.include?(:comments) }
           .from false
 
-        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
-        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+        expect(output).to include "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
+        expect(output).not_to include "db/main.sqlite3"
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       db_structure_dump
     end
 
@@ -102,14 +102,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
         .to true
 
       expect(output).to include_in_order(
-        "db/app.sqlite3 structure loaded from config/db/structure.sql",
-        "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql"
+        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
+        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql"
       )
     end
 
     context "app with gateways" do
       def before_prepare
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
 
         write "config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -130,8 +130,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "db/app.sqlite3 structure loaded from config/db/structure.sql in",
-          "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql in",
+          "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
         )
       end
 
@@ -142,14 +142,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Hanami.app["db.gateways.default"].connection.tables.include?(:posts) }
           .from false
 
-        expect(output).to include "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
     end
 
     context "slice with gateways" do
       def before_prepare
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
 
         write "slices/main/config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -170,8 +170,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql in",
-          "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql in",
+          "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
         )
       end
 
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Main::Slice["db.gateways.default"].connection.tables.include?(:comments) }
           .from false
 
-        expect(output).to include "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
     end
   end
@@ -281,7 +281,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
 
   describe "sqlite" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+      ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
       db_structure_dump
     end
 
@@ -102,14 +102,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
         .to true
 
       expect(output).to include_in_order(
-        "db/app.sqlite3 structure loaded from config/db/structure.sql",
-        "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql"
+        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql",
+        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql"
       )
     end
 
     context "app with gateways" do
       def before_prepare
-        ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
 
         write "config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -130,8 +130,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "db/app.sqlite3 structure loaded from config/db/structure.sql in",
-          "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
+          "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} structure loaded from config/db/structure.sql in",
+          "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
         )
       end
 
@@ -142,14 +142,14 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Hanami.app["db.gateways.default"].connection.tables.include?(:posts) }
           .from false
 
-        expect(output).to include "db/app_extra.sqlite3 structure loaded from config/db/extra_structure.sql in"
-        expect(output).not_to include "db/app.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} structure loaded from config/db/extra_structure.sql in"
+        expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
       end
     end
 
     context "slice with gateways" do
       def before_prepare
-        ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
 
         write "slices/main/config/db/extra_migrate/20240602201330_create_users.rb", <<~RUBY
           ROM::SQL.migration do
@@ -170,8 +170,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .to true
 
         expect(output).to include_in_order(
-          "db/main.sqlite3 structure loaded from slices/main/config/db/structure.sql in",
-          "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
+          "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/structure.sql in",
+          "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
         )
       end
 
@@ -182,8 +182,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           .and not_change { Main::Slice["db.gateways.default"].connection.tables.include?(:comments) }
           .from false
 
-        expect(output).to include "db/main_extra.sqlite3 structure loaded from slices/main/config/db/extra_structure.sql in"
-        expect(output).not_to include "db/main.sqlite3"
+        expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} structure loaded from slices/main/config/db/extra_structure.sql in"
+        expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
       end
     end
   end
@@ -285,7 +285,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
 
   describe "automatic test env execution" do
     before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
     end
 
     around do |example|

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
   end
 
   before do
-    ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-    ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
+    ENV["DATABASE_URL"] = sqlite_url("db/app.sqlite3", dir: @dir)
+    ENV["MAIN__DATABASE_URL"] = sqlite_url("db/main.sqlite3", dir: @dir)
 
     db_migrate
   end
@@ -74,29 +74,29 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
     command.call
 
     expect(output).to include_in_order(
-      "db/app.sqlite3 current schema version is 20240602191330_create_categories",
-      "db/main.sqlite3 current schema version is 20240602211330_create_comments"
+      "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories",
+      "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments"
     )
   end
 
   it "prints the version of the app db only when given --app" do
     command.call(app: true)
 
-    expect(output).to include "db/app.sqlite3 current schema version is 20240602191330_create_categories"
-    expect(output).not_to include "db/main.sqlite3"
+    expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories"
+    expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
   end
 
   it "prints the version of a slice when given --slice" do
     command.call(slice: "main")
 
-    expect(output).to include "db/main.sqlite3 current schema version is 20240602211330_create_comments"
+    expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments"
     expect(output).not_to include "db/app.db"
   end
 
   it "prints an error when given a slice without migrations" do
     command.call(slice: "admin")
 
-    expect(output).to include %(Cannot find version for database db/app.sqlite3: no migrations directory at slices/admin/config/db/migrate/)
+    expect(output).to include %(Cannot find version for database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}: no migrations directory at slices/admin/config/db/migrate/)
     expect(output).not_to include "current schema version"
   end
 
@@ -113,23 +113,23 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
         end
       RUBY
 
-      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+      ENV["DATABASE_URL__EXTRA"] = sqlite_url("db/app_extra.sqlite3", dir: @dir)
     end
 
     it "prints the versions for all an app's databases when given --app" do
       command.call(app: true)
 
       expect(output).to include_in_order(
-        "db/app.sqlite3 current schema version is 20240602191330_create_categories",
-        "db/app_extra.sqlite3 current schema version is 20240921211330_create_users"
+        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories",
+        "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
       )
     end
 
     it "prints the version for a single gateway database when given --app and --gateway" do
       command.call(app: true, gateway: "extra")
 
-      expect(output).to include "db/app_extra.sqlite3 current schema version is 20240921211330_create_users"
-      expect(output).not_to include "db/app.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
+      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
     end
   end
 
@@ -146,23 +146,23 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
         end
       RUBY
 
-      ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+      ENV["MAIN__DATABASE_URL__EXTRA"] = sqlite_url("db/main_extra.sqlite3", dir: @dir)
     end
 
     it "prints the versions for all an app's databases when given --app" do
       command.call(slice: "main")
 
       expect(output).to include_in_order(
-        "db/main.sqlite3 current schema version is 20240602211330_create_comments",
-        "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
+        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments",
+        "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
       )
     end
 
     it "prints the version for a single gateway database when given --app and --gateway" do
       command.call(slice: "main", gateway: "extra")
 
-      expect(output).to include "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
-      expect(output).not_to include "db/main.sqlite3"
+      expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
+      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -74,29 +74,29 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
     command.call
 
     expect(output).to include_in_order(
-      "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories",
-      "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments"
+      "db/app.sqlite3 current schema version is 20240602191330_create_categories",
+      "db/main.sqlite3 current schema version is 20240602211330_create_comments"
     )
   end
 
   it "prints the version of the app db only when given --app" do
     command.call(app: true)
 
-    expect(output).to include "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories"
-    expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+    expect(output).to include "db/app.sqlite3 current schema version is 20240602191330_create_categories"
+    expect(output).not_to include "db/main.sqlite3"
   end
 
   it "prints the version of a slice when given --slice" do
     command.call(slice: "main")
 
-    expect(output).to include "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments"
+    expect(output).to include "db/main.sqlite3 current schema version is 20240602211330_create_comments"
     expect(output).not_to include "db/app.db"
   end
 
   it "prints an error when given a slice without migrations" do
     command.call(slice: "admin")
 
-    expect(output).to include %(Cannot find version for database #{sqlite_db_name("db/app.sqlite3", dir: @dir)}: no migrations directory at slices/admin/config/db/migrate/)
+    expect(output).to include %(Cannot find version for database db/app.sqlite3: no migrations directory at slices/admin/config/db/migrate/)
     expect(output).not_to include "current schema version"
   end
 
@@ -120,16 +120,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
       command.call(app: true)
 
       expect(output).to include_in_order(
-        "#{sqlite_db_name("db/app.sqlite3", dir: @dir)} current schema version is 20240602191330_create_categories",
-        "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
+        "db/app.sqlite3 current schema version is 20240602191330_create_categories",
+        "db/app_extra.sqlite3 current schema version is 20240921211330_create_users"
       )
     end
 
     it "prints the version for a single gateway database when given --app and --gateway" do
       command.call(app: true, gateway: "extra")
 
-      expect(output).to include "#{sqlite_db_name("db/app_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
-      expect(output).not_to include sqlite_db_name("db/app.sqlite3", dir: @dir)
+      expect(output).to include "db/app_extra.sqlite3 current schema version is 20240921211330_create_users"
+      expect(output).not_to include "db/app.sqlite3"
     end
   end
 
@@ -153,16 +153,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
       command.call(slice: "main")
 
       expect(output).to include_in_order(
-        "#{sqlite_db_name("db/main.sqlite3", dir: @dir)} current schema version is 20240602211330_create_comments",
-        "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
+        "db/main.sqlite3 current schema version is 20240602211330_create_comments",
+        "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
       )
     end
 
     it "prints the version for a single gateway database when given --app and --gateway" do
       command.call(slice: "main", gateway: "extra")
 
-      expect(output).to include "#{sqlite_db_name("db/main_extra.sqlite3", dir: @dir)} current schema version is 20240921211330_create_users"
-      expect(output).not_to include sqlite_db_name("db/main.sqlite3", dir: @dir)
+      expect(output).to include "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
+      expect(output).not_to include "db/main.sqlite3"
     end
   end
 end


### PR DESCRIPTION
Support SQLite3 JDBC adapter.

This is a messy change, because of some differences betreen CRuby and JRuby adapters. Notably:
* JDBC adapter seems to expect the directory for the database file to already exists, CRuby's SQLite3 driver creates it
* `Dir.chdir` is not effective in JRuby for gems calling external JARs and I haven't found an equivalent for JVM - meaning we need to use absolute paths for temporary directories in tests
* Ruby's `URI` does not parse JDBC-compatible URIs well (`jdbc:sqlite:db/dev.sqlite`)

Good news is that I think this is the most messy one and it should be more straightforward for PostgreSQL and MySQL.