### PR TITLE
Fix typo in assets.js

### DIFF
--- a/lib/hanami/cli/generators/gem/app/assets.js
+++ b/lib/hanami/cli/generators/gem/app/assets.js
@@ -9,7 +9,7 @@ await assets.run({
   esbuildOptionsFn: (args, esbuildOptions) => {
     // Customize your `esbuildOptions` here.
     //
-    // Use the `args.watch` boolean as a condition to apply diffierent options
+    // Use the `args.watch` boolean as a condition to apply different options
     // when running `hanami assets watch` vs `hanami assets compile`.
 
     return esbuildOptions;


### PR DESCRIPTION
Correct typo `diffierent -> different`