### PR TITLE
Make typo in specs

### DIFF
--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           esbuildOptionsFn: (args, esbuildOptions) => {
             // Customize your `esbuildOptions` here.
             //
-            // Use the `args.watch` boolean as a condition to apply diffierent options
+            // Use the `args.watch` boolean as a condition to apply different options
             // when running `hanami assets watch` vs `hanami assets compile`.
 
             return esbuildOptions;
@@ -1024,7 +1024,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
             esbuildOptionsFn: (args, esbuildOptions) => {
               // Customize your `esbuildOptions` here.
               //
-              // Use the `args.watch` boolean as a condition to apply diffierent options
+              // Use the `args.watch` boolean as a condition to apply different options
               // when running `hanami assets watch` vs `hanami assets compile`.
 
               return esbuildOptions;


### PR DESCRIPTION
c0e0ce1a8670 ("Fix typo in assets.js (#439)") fixed the typo, but the tests were testing against the same typo making the test suite fail. Fix the typo in the specs as well.

Disclaimer: I didn't run the test suite locally as it the I didn't want to install the mysqlclient library to satisfy the mysql2 dependency. But based on the GitHub action output I'm ~confident that the change will fix the failures.