### PR TITLE
Add `hanami new --skip-git` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- Add `hanami new --skip-git` to generate an app without initializing a git repository or generating a `.gitignore`.
+  (@aaronmallen #441)
+
 ### Changed
 
 - Print clearer errors when Postgres CLI commands fail. (@mddelk in #437)

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -19,6 +19,7 @@ module Hanami
           SKIP_DB_DEFAULT = false
           SKIP_VIEW_DEFAULT = false
           SKIP_MAILER_DEFAULT = false
+          SKIP_GIT_DEFAULT = false
 
           DATABASE_SQLITE = "sqlite"
           DATABASE_POSTGRES = "postgres"
@@ -63,6 +64,10 @@ module Hanami
             default: SKIP_MAILER_DEFAULT,
             desc: "Skip including hanami-mailer"
 
+          option :skip_git, type: :flag, required: false,
+            default: SKIP_GIT_DEFAULT,
+            desc: "Skip git repository initialization (and `.gitignore' generation)"
+
           option :database, type: :string, required: false,
             default: DATABASE_SQLITE,
             desc: "Database adapter (supported: sqlite, mysql, postgres)"
@@ -90,6 +95,7 @@ module Hanami
             "bookshelf --skip-db                          # Generate a new Hanami app without hanami-db",
             "bookshelf --skip-view                        # Generate a new Hanami app without hanami-view",
             "bookshelf --skip-mailer                      # Generate a new Hanami app without hanami-mailer",
+            "bookshelf --skip-git                         # Generate a new Hanami app without git repository initialization",
             "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)",
             "bookshelf --template-engine={erb|haml|slim}  # Generate a new Hanami app which will use HAML for templates by default (default: erb)",
             "bookshelf --test={rspec|minitest}            # Generate a new Hanami app with specified test framework (default: rspec)",
@@ -121,6 +127,7 @@ module Hanami
             skip_db: SKIP_DB_DEFAULT,
             skip_view: SKIP_VIEW_DEFAULT,
             skip_mailer: SKIP_MAILER_DEFAULT,
+            skip_git: SKIP_GIT_DEFAULT,
             database: nil,
             name: nil,
             template_engine: TEMPLATE_ENGINE_DEFAULT,
@@ -145,6 +152,7 @@ module Hanami
                 skip_db:,
                 skip_view:,
                 skip_mailer:,
+                skip_git:,
                 database: normalized_database,
                 template_engine:,
                 test_framework: test
@@ -172,8 +180,10 @@ module Hanami
                   out.puts "Running bundle binstubs hanami-cli rake..."
                   install_binstubs!
 
-                  out.puts "Initializing git repository..."
-                  init_git_repository
+                  unless skip_git
+                    out.puts "Initializing git repository..."
+                    init_git_repository
+                  end
                 end
               end
             end

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -92,6 +92,10 @@ module Hanami
           !options.fetch(:skip_mailer, false)
         end
 
+        def generate_git?
+          !options.fetch(:skip_git, false)
+        end
+
         def generate_sqlite?
           generate_db? && database_option == Commands::Gem::New::DATABASE_SQLITE
         end

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -34,7 +34,7 @@ module Hanami
           attr_reader :inflector
 
           def generate_app(app, context) # rubocop:disable Metrics/AbcSize
-            fs.create(".gitignore", t("gitignore.erb", context))
+            fs.create(".gitignore", t("gitignore.erb", context)) if context.generate_git?
             fs.create(".env", t("env.erb", context))
 
             fs.create("README.md", t("readme.erb", context))

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -11,13 +11,16 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:inflector) { Dry::Inflector.new }
   let(:system_call) { instance_double(Hanami::CLI::SystemCall, call: successful_system_call_result) }
   let(:app) { "bookshelf" }
-  let(:kwargs) { {head: hanami_head, skip_assets:, skip_db:, skip_view:, skip_mailer:, database:} }
+  let(:kwargs) do
+    {head: hanami_head, skip_assets:, skip_db:, skip_view:, skip_mailer:, skip_git:, database:}
+  end
 
   let(:hanami_head) { false }
   let(:skip_assets) { false }
   let(:skip_db) { false }
   let(:skip_view) { false }
   let(:skip_mailer) { false }
+  let(:skip_git) { false }
   let(:database) { nil }
 
   let(:output) { out.rewind && out.read.chomp }
@@ -1929,5 +1932,36 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
     expect(fs.directory?(app)).to be(true)
     expect(output).to include("Initializing git repository...")
+  end
+
+  context "without git" do
+    let(:skip_git) { true }
+
+    it "generates a new app without initializing a git repository" do
+      expect(bundler).to receive(:install!)
+        .and_return(true)
+
+      expect(bundler).to receive(:exec)
+        .with("hanami install")
+        .and_return(successful_system_call_result)
+
+      expect(bundler).to receive(:exec)
+        .with("check")
+        .at_least(1)
+        .and_return(successful_system_call_result)
+
+      expect(system_call).to receive(:call).with("npm", ["install"])
+
+      expect(system_call).to_not receive(:call).with("git", ["init"])
+
+      subject.call(app: app, **kwargs)
+
+      expect(fs.directory?(app)).to be(true)
+      expect(output).to_not include("Initializing git repository...")
+
+      fs.chdir(app) do
+        expect(fs.exist?(".gitignore")).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Generating an app with `--skip-git` skips the `git init` step and the `.gitignore` file, for cases where the app is being generated into an existing repository or is not version controlled at all.