### PR TITLE
Reload the console in place instead of re-execing it

### DIFF
--- a/lib/hanami/console/context.rb
+++ b/lib/hanami/console/context.rb
@@ -26,6 +26,32 @@ module Hanami
         Plugins::UnbootedSliceWarnings.activate
       end
 
+      # Reloads the app in place, for the console's `reload` method.
+      #
+      # Reloading in place keeps the session: local variables, history and anything else built up
+      # so far survive, where re-execing the console threw all of it away.
+      #
+      # Constants captured before the reload are the exception. They still point at the classes
+      # they did when they were captured, so anything held in a variable is stale afterwards.
+      #
+      # @api private
+      # @since 3.1.0
+      def self.reload_app(app)
+        # Either an older Hanami without in-place reloading, or an app that has it turned off.
+        unless app.respond_to?(:reload!) && app.config.code_reloading
+          puts "Reloading..."
+          return Kernel.exec("#{$PROGRAM_NAME} console")
+        end
+
+        print "Reloading... "
+
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        app.reload!
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        puts "done (#{(elapsed * 1000).round}ms)"
+      end
+
       private
 
       def define_context_methods
@@ -40,8 +66,14 @@ module Hanami
         end
 
         define_method(:reload) do
-          puts "Reloading..."
-          Kernel.exec("#{$PROGRAM_NAME} console")
+          Context.reload_app(hanami_app)
+        end
+
+        # `reload!` would otherwise fall through to `Hanami.app.reload!` via #method_missing,
+        # skipping both the output above and the fallback for apps that cannot reload in place.
+        # It is a common enough thing to reach for that it should do the same as `reload`.
+        define_method(:reload!) do
+          Context.reload_app(hanami_app)
         end
 
         define_method(:method_missing) do |name, *args, &block|

--- a/lib/hanami/console/plugins/slice_readers.rb
+++ b/lib/hanami/console/plugins/slice_readers.rb
@@ -14,8 +14,13 @@ module Hanami
           super()
 
           app.slices.each do |slice|
-            define_method(slice.slice_name.to_sym) do
-              slice
+            slice_name = slice.slice_name.to_sym
+
+            # Looked up on each call rather than closed over, because reloading the app replaces
+            # its slice classes. Closing over the slice would leave the console handing out a
+            # class whose container had already been discarded.
+            define_method(slice_name) do
+              app.slices[slice_name]
             end
           end
         end

--- a/spec/unit/hanami/console/context_spec.rb
+++ b/spec/unit/hanami/console/context_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Console::Context do
+  subject(:console_env) { Object.new.extend(described_class.new(app)) }
+
+  after { Hanami::Console::Plugins::UnbootedSliceWarnings.deactivate }
+
+  # Real objects rather than doubles: the code under test asks `respond_to?(:reload!)`, which a
+  # double cannot answer honestly.
+  def build_app(code_reloading:, reloadable:)
+    config = Class.new do
+      def initialize(code_reloading) = @code_reloading = code_reloading
+      attr_reader :code_reloading
+
+      def console = Struct.new(:extensions).new([])
+    end.new(code_reloading)
+
+    klass = Class.new do
+      attr_reader :config, :reloads
+
+      def initialize(config)
+        @config = config
+        @reloads = 0
+      end
+
+      def slices = []
+    end
+
+    klass.define_method(:reload!) { @reloads += 1 } if reloadable
+
+    klass.new(config)
+  end
+
+  describe "#reload" do
+    context "when the app can reload in place" do
+      let(:app) { build_app(code_reloading: true, reloadable: true) }
+
+      it "reloads the app and reports how long it took" do
+        expect { console_env.reload }.to output(/Reloading\.\.\. done \(\d+ms\)/).to_stdout
+
+        expect(app.reloads).to eq(1)
+      end
+
+      it "does not replace the process, so the session survives" do
+        expect(Kernel).not_to receive(:exec)
+
+        expect { console_env.reload }.to output.to_stdout
+      end
+
+      it "is also available as `reload!`, which Rails users reach for" do
+        expect { console_env.reload! }.to output(/Reloading\.\.\. done/).to_stdout
+
+        expect(app.reloads).to eq(1)
+      end
+    end
+
+    context "when the app has code reloading disabled" do
+      let(:app) { build_app(code_reloading: false, reloadable: true) }
+
+      it "falls back to re-execing the console" do
+        expect(Kernel).to receive(:exec).with(/console/)
+
+        expect { console_env.reload }.to output(/Reloading\.\.\./).to_stdout
+      end
+    end
+
+    context "when the app predates in-place reloading" do
+      let(:app) { build_app(code_reloading: true, reloadable: false) }
+
+      it "falls back to re-execing the console" do
+        expect(Kernel).to receive(:exec).with(/console/)
+
+        expect { console_env.reload }.to output(/Reloading\.\.\./).to_stdout
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/console/plugins/slice_readers_spec.rb
+++ b/spec/unit/hanami/console/plugins/slice_readers_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Console::Plugins::SliceReaders do
+  subject(:console_env) { Object.new.extend(described_class.new(app)) }
+
+  # Stands in for a SliceRegistrar: enumerable for building the readers, and indexable for
+  # resolving a slice by name afterwards.
+  let(:registry) do
+    Class.new do
+      attr_accessor :current
+
+      def initialize(slices) = @slices = slices
+      def each(&) = @slices.each(&)
+      def [](_name) = @current
+    end.new([double("slice", slice_name: :shop)])
+  end
+
+  let(:app) { double("app", slices: registry) }
+
+  let(:slice_before) { double("slice before reload") }
+  let(:slice_after) { double("slice after reload") }
+
+  it "defines a reader named after each slice" do
+    registry.current = slice_before
+
+    expect(console_env).to respond_to(:shop)
+    expect(console_env.shop).to be(slice_before)
+  end
+
+  it "resolves the slice on each call, so a reload does not leave it stale" do
+    # Reloading replaces slice class objects. A reader that closed over the slice it saw at
+    # console start would keep handing out one whose container had already been discarded.
+    registry.current = slice_before
+    expect(console_env.shop).to be(slice_before)
+
+    registry.current = slice_after
+    expect(console_env.shop).to be(slice_after)
+  end
+end


### PR DESCRIPTION
`reload` re-execed the console to pick up a code change, throwing away the session: local variables, history, everything built up so far. Hanami can now reload in place via `Hanami::Slice#reload!`, so the session survives. `reload!` is accepted too, since it is what Rails users reach for.

Apps that cannot reload in place, either an older Hanami or one with `config.code_reloading` off, re-exec exactly as before.

Slice readers now resolve through `app.slices` on each call. A reload replaces slice classes, so a reader that closed over the slice it saw at console start would hand out one whose container had been discarded.

This is safe to go in once the Hanami slice reloading goes in, though technically it could go in now if we wanted it to and we were happy with the dev api the reloader and slice reloading will take.

See: https://github.com/hanami/hanami/pull/1625
https://github.com/hanami/hanami-reloader/pull/37 for related code.