### PR TITLE
Generate settings YAML files for new apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 - Add `hanami new --skip-git` to generate an app without initializing a git repository or generating a `.gitignore`.
   (@aaronmallen #441)
+- Generate `config/settings/default.yml` and per-environment `config/settings/development.yml`, `config/settings/test.yml`
+  and `config/settings/production.yml` for new apps. (@aaronmallen)
 
 ### Changed
 

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -51,6 +51,10 @@ module Hanami
 
             fs.create("config/app.rb", t("app.erb", context))
             fs.create("config/settings.rb", t("settings.erb", context))
+            fs.create("config/settings/default.yml", file("settings_default.yml"))
+            fs.create("config/settings/development.yml", file("settings_development.yml"))
+            fs.create("config/settings/test.yml", file("settings_test.yml"))
+            fs.create("config/settings/production.yml", file("settings_production.yml"))
             fs.create("config/routes.rb", t("routes.erb", context))
             fs.create("config/puma.rb", t("puma.erb", context))
             fs.create("config/i18n/en.yml", File.read(File.join(__dir__, "..", "i18n.yml")))

--- a/lib/hanami/cli/generators/gem/app/settings_default.yml
+++ b/lib/hanami/cli/generators/gem/app/settings_default.yml
@@ -1,0 +1,13 @@
+# Settings shared by every environment.
+#
+# Values here are overridden by config/settings/<HANAMI_ENV>.yml, and both are
+# overridden by matching (upper-cased) ENV variables.
+#
+# A setting must be declared in config/settings.rb before it can be given a
+# value here.
+#
+# This file is evaluated as ERB, so values can be computed:
+#
+#   site_name: <%= Hanami.env?(:test) ? "test_site" : "site" %>
+#
+# See https://hanakai.org/learn/hanami/app/settings for details.

--- a/lib/hanami/cli/generators/gem/app/settings_development.yml
+++ b/lib/hanami/cli/generators/gem/app/settings_development.yml
@@ -1,0 +1,6 @@
+# Settings for the development environment.
+#
+# Values here override config/settings/default.yml, and are overridden by
+# matching (upper-cased) ENV variables.
+#
+# This file is evaluated as ERB. See config/settings/default.yml for details.

--- a/lib/hanami/cli/generators/gem/app/settings_production.yml
+++ b/lib/hanami/cli/generators/gem/app/settings_production.yml
@@ -1,0 +1,6 @@
+# Settings for the production environment.
+#
+# Values here override config/settings/default.yml, and are overridden by
+# matching (upper-cased) ENV variables.
+#
+# This file is evaluated as ERB. See config/settings/default.yml for details.

--- a/lib/hanami/cli/generators/gem/app/settings_test.yml
+++ b/lib/hanami/cli/generators/gem/app/settings_test.yml
@@ -1,0 +1,6 @@
+# Settings for the test environment.
+#
+# Values here override config/settings/default.yml, and are overridden by
+# matching (upper-cased) ENV variables.
+#
+# This file is evaluated as ERB. See config/settings/default.yml for details.

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -361,6 +361,38 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("config/settings.rb")).to eq(settings)
       expect(output).to include("Created config/settings.rb")
 
+      # config/settings/*.yml
+      settings_default = <<~EXPECTED
+        # Settings shared by every environment.
+        #
+        # Values here are overridden by config/settings/<HANAMI_ENV>.yml, and both are
+        # overridden by matching (upper-cased) ENV variables.
+        #
+        # A setting must be declared in config/settings.rb before it can be given a
+        # value here.
+        #
+        # This file is evaluated as ERB, so values can be computed:
+        #
+        #   site_name: <%= Hanami.env?(:test) ? "test_site" : "site" %>
+        #
+        # See https://hanakai.org/learn/hanami/app/settings for details.
+      EXPECTED
+      expect(fs.read("config/settings/default.yml")).to eq(settings_default)
+      expect(output).to include("Created config/settings/default.yml")
+
+      %w[development test production].each do |env|
+        settings_env = <<~EXPECTED
+          # Settings for the #{env} environment.
+          #
+          # Values here override config/settings/default.yml, and are overridden by
+          # matching (upper-cased) ENV variables.
+          #
+          # This file is evaluated as ERB. See config/settings/default.yml for details.
+        EXPECTED
+        expect(fs.read("config/settings/#{env}.yml")).to eq(settings_env)
+        expect(output).to include("Created config/settings/#{env}.yml")
+      end
+
       # config/routes.rb
       routes = <<~EXPECTED
         # frozen_string_literal: true
@@ -1051,6 +1083,38 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("config/settings.rb")).to eq(settings)
         expect(output).to include("Created config/settings.rb")
+
+        # config/settings/*.yml
+        settings_default = <<~EXPECTED
+          # Settings shared by every environment.
+          #
+          # Values here are overridden by config/settings/<HANAMI_ENV>.yml, and both are
+          # overridden by matching (upper-cased) ENV variables.
+          #
+          # A setting must be declared in config/settings.rb before it can be given a
+          # value here.
+          #
+          # This file is evaluated as ERB, so values can be computed:
+          #
+          #   site_name: <%= Hanami.env?(:test) ? "test_site" : "site" %>
+          #
+          # See https://hanakai.org/learn/hanami/app/settings for details.
+        EXPECTED
+        expect(fs.read("config/settings/default.yml")).to eq(settings_default)
+        expect(output).to include("Created config/settings/default.yml")
+
+        %w[development test production].each do |env|
+          settings_env = <<~EXPECTED
+            # Settings for the #{env} environment.
+            #
+            # Values here override config/settings/default.yml, and are overridden by
+            # matching (upper-cased) ENV variables.
+            #
+            # This file is evaluated as ERB. See config/settings/default.yml for details.
+          EXPECTED
+          expect(fs.read("config/settings/#{env}.yml")).to eq(settings_env)
+          expect(output).to include("Created config/settings/#{env}.yml")
+        end
 
         # config/routes.rb
         routes = <<~EXPECTED


### PR DESCRIPTION
Generates `config/settings/default.yml` and a file for each environment (`development.yml`, `test.yml`, `production.yml`) as part of `hanami new`.

> [!IMPORTANT]
> Depends on [hanami#1627](https://github.com/hanami/hanami/pull/1627), which adds the YAML settings store that reads these files. This should not be released ahead of it.

## Why

[hanami#1627](https://github.com/hanami/hanami/pull/1627) lets settings be loaded from `config/settings/*.yml` in addition to `ENV`, which is useful where `ENV` alone is awkward: the files are evaluated as ERB so a setting can be computed, they keep non-secret environment-varying config in the repo where it is reviewable in a diff, and they give shared defaults a natural home with per-environment overrides layered on top.

Generating the files gives a new app an obvious place to put those settings, and somewhere to document how the layering works at the moment a developer first goes looking for it.

## What's generated

```
config/settings/default.yml
config/settings/development.yml
config/settings/test.yml
config/settings/production.yml
```

Every file is comments only. `default.yml` documents the precedence chain and the ERB capability:

```yaml
# Settings shared by every environment.
#
# Values here are overridden by config/settings/<HANAMI_ENV>.yml, and both are
# overridden by matching (upper-cased) ENV variables.
#
# A setting must be declared in config/settings.rb before it can be given a
# value here.
#
# This file is evaluated as ERB, so values can be computed:
#
#   site_name: <%= Hanami.env?(:test) ? "test_site" : "site" %>
#
# See https://hanakai.org/learn/hanami/app/settings for details.
```

The per-environment files carry a shorter header naming their environment and pointing back at `default.yml`.

Since the files hold no active keys, a generated app resolves every setting from `ENV` exactly as it does today. `.env` keeps owning `DATABASE_URL` and friends; nothing about how a new app boots changes.

## Notes

- The templates are static, so they are generated with `file()` rather than `t()`, as with `assets.js`, `404.html` and `i18n.yml`.
- Against a released hanami, where the YAML store does not exist, the files are inert rather than an error.
- Slices are unaffected: the settings files are read from the app root and shared by the app and all of its slices, in the same way as `ENV`.