### PR TITLE
Display relative path to SQLite DB on JRuby

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -79,15 +79,7 @@ module Hanami
               end
 
               def name
-                path = database_path
-                # On JRuby we probably converted a relative path to an absolute path, because
-                # the JDBC driver only accepts the latter. Now it's time to convert it back.
-                # This means that JRuby users might sometimes see relative path when they actually
-                # used abosulte path in the configuration.
-                if jruby?
-                  pathname = Pathname.new(path).expand_path
-                  path = pathname.relative_path_from(Dir.current).to_s if pathname.to_s.start_with?("#{Dir.current}/")
-                end
+                path = relativize_for_display(database_path)
                 path.sub(%r{^/}, "")
               end
 
@@ -214,6 +206,22 @@ module Hanami
 
               def jruby?
                 RUBY_ENGINE == "jruby"
+              end
+
+              def relativize_for_display(path)
+                # On JRuby we probably converted a relative path to an absolute path, because
+                # the JDBC driver only accepts the latter. Now it's time to convert it back.
+                # This means that JRuby users might sometimes see relative path when they actually
+                # used abosulte path in the configuration.
+                return path unless jruby?
+
+                pathname = Pathname.new(path).expand_path
+                expanded = pathname.to_s
+
+                bases = [slice.app.root.to_s, Dir.pwd.to_s]
+
+                base = bases.find { |b| expanded.start_with?("#{b}/") }
+                base ? pathname.relative_path_from(base).to_s : path
               end
 
               def post_process_dump(sql)

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -79,8 +79,7 @@ module Hanami
               end
 
               def name
-                path = relativize_for_display(database_path)
-                path.sub(%r{^/}, "")
+                database_uri.path.sub(%r{^/}, "")
               end
 
               def database_url
@@ -206,22 +205,6 @@ module Hanami
 
               def jruby?
                 RUBY_ENGINE == "jruby"
-              end
-
-              def relativize_for_display(path)
-                # On JRuby we probably converted a relative path to an absolute path, because
-                # the JDBC driver only accepts the latter. Now it's time to convert it back.
-                # This means that JRuby users might sometimes see relative path when they actually
-                # used abosulte path in the configuration.
-                return path unless jruby?
-
-                pathname = Pathname.new(path).expand_path
-                expanded = pathname.to_s
-
-                bases = [slice.app.root.to_s, Dir.pwd.to_s]
-
-                base = bases.find { |b| expanded.start_with?("#{b}/") }
-                base ? pathname.relative_path_from(base).to_s : path
               end
 
               def post_process_dump(sql)

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -96,6 +96,22 @@ module Hanami
                     slice.app.root.join(name).to_s
                   end
               end
+
+              def relativize_for_display(path)
+                # On JRuby we probably converted a relative path to an absolute path, because
+                # the JDBC driver only accepts the latter. Now it's time to convert it back.
+                # This means that JRuby users might sometimes see relative path when they actually
+                # used abosulte path in the configuration.
+                return path unless jruby?
+
+                pathname = Pathname.new(path).expand_path
+                expanded = pathname.to_s
+
+                bases = [slice.app.root.to_s, Dir.pwd.to_s]
+
+                base = bases.find { |b| expanded.start_with?("#{b}/") }
+                base ? pathname.relative_path_from(base).to_s : path
+              end
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -68,16 +68,21 @@ module Hanami
               # @since 2.2.0
               def name
                 @name ||=
-                  if database_uri.scheme == "jdbc"
-                    # For JDBC SQLite URIs like "jdbc:sqlite:db/app.sqlite3",
-                    # we need to extract the path part after "jdbc:sqlite:"
-                    # The standard URI.parse doesn't handle JDBC URIs well, so we remove the prefix manually
-                    database_url.sub(%r{^jdbc:sqlite:}, "")
-                  else
-                    # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
-                    # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
-                    # of the path is considered by Ruby's `URI` as the `#host`.
-                    "#{database_uri.host}#{database_uri.path}"
+                  begin
+                    raw =
+                      if database_uri.scheme == "jdbc"
+                        # For JDBC SQLite URIs like "jdbc:sqlite:db/app.sqlite3",
+                        # we need to extract the path part after "jdbc:sqlite:"
+                        # The standard URI.parse doesn't handle JDBC URIs well, so we remove the prefix manually
+                        database_url.sub(%r{^jdbc:sqlite:}, "")
+                      else
+                        # Sequel expects sqlite:// URIs to operate the same as file:// URIs: 2 slashes for
+                        # a relative path, 3 for an absolute path. In the case of 2 slashes, the first part
+                        # of the path is considered by Ruby's `URI` as the `#host`.
+                        "#{database_uri.host}#{database_uri.path}"
+                      end
+
+                    relativize_for_display(raw).sub(%r{^/}, "")
                   end
               end
 


### PR DESCRIPTION
The last minute change in #434 was incorrect. The database path was changed to relative in `database.rb`, but `sqlite.rb` overrode it, displaying absolute path and causing 46 specs to fail unnecessarily. Also, I somehow sneaked in `Dir.current` call, which does not exist - switching to `Dir.pwd` instead.